### PR TITLE
enabled key enter behaviour in V9 floating version

### DIFF
--- a/lib/doofinder_layer_api.php
+++ b/lib/doofinder_layer_api.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ * @author    Doofinder
+ * @copyright Doofinder
+ * @license   GPLv3
+ *
+ */
+
+require_once _PS_MODULE_DIR_ . 'doofinder/lib/EasyREST.php';
+
+class DoofinderLayerApi
+{
+    /**
+     * Function that returns a hashid given an installationID, currency and language. 
+     * Since this API returns the default hashid if both currency and language do not match, 
+     * a check is made to see if the desired hashid is returned.
+     */
+    public static function getHashidByInstallationID($installationID, $currency, $language) {
+        $client = new EasyREST();
+        $api_endpoint = "https://eu1-layer.doofinder.com/api/1/installation/".$installationID.'?currency='.$currency.'&language='.$language;
+
+        $response = $client->get($api_endpoint);
+
+        if($response->headers['code'] === 200){
+            $options = json_decode($response->response)->options;
+            if($currency === $options->currency && $language === $options->language)
+            {
+                return $options->hashid;
+            }
+        }
+        
+        return null;
+    }
+}


### PR DESCRIPTION
Related task: [https://doofinder.atlassian.net/browse/PSN-86](https://doofinder.atlassian.net/browse/PSN-86)

As a Prestashop customer I want to configure the behaviour of ENTER in the floating version of Live Layer so that I can decide if the results will be shown in a separate page (native search).

Additionally an additional check has been added to activate this option for V9. On the other hand, the possibility to switch back to V7 if you have V9 active has been removed.

![Captura de pantalla de 2022-05-30 13-19-23](https://user-images.githubusercontent.com/97886896/171006671-153ca98a-ae83-4f61-b45e-6305e5d59821.png)
