### PR TITLE
Fixed issues with protocol in region

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -46,7 +46,7 @@ class Doofinder extends Module
 
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.3.0';
+    const VERSION = '4.3.1';
     const YES = 1;
     const NO = 0;
 
@@ -54,7 +54,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.3.0';
+        $this->version = '4.3.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = array('min' => '1.5', 'max' => '1.7');
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
@@ -2502,6 +2502,7 @@ class Doofinder extends Module
 
         $api_endpoint_array = explode('-', $api_endpoint);
         $region = $api_endpoint_array[0];
+        $region = preg_replace('/^https?:\/\//m', '', $region); //Replace the protocol
         $shops = Shop::getShops();
         foreach ($shops as $shop) {
             $sid = $shop['id_shop'];
@@ -2628,6 +2629,7 @@ class Doofinder extends Module
         $api_endpoint = Configuration::getGlobalValue('DF_AI_API_ENDPOINT');
         $api_endpoint_array = explode('-', $api_endpoint);
         $region = $api_endpoint_array[0];
+        $region = preg_replace('/^https?:\/\//m', '', $region); //Replace the protocol
 
         Configuration::updateValue('DF_ENABLE_HASH', true, false, $shopGroupId, $shopId);
         Configuration::updateValue('DF_GS_DISPLAY_PRICES', true, false, $shopGroupId, $shopId);

--- a/lib/doofinder_api.php
+++ b/lib/doofinder_api.php
@@ -71,6 +71,7 @@ class DoofinderApi
         if (2 === count($zone_key_array)) {
             $this->api_key = $zone_key_array[1];
             $this->zone = $zone_key_array[0];
+            $this->zone = preg_replace('/^https?:\/\//m', '', $this->zone);
             $this->url = "https://" . $this->zone . self::URL_SUFFIX;
         } else {
             throw new DoofinderException("API Key is no properly set.");

--- a/lib/doofinder_api.php
+++ b/lib/doofinder_api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * NOTICE OF LICENSE
  *
@@ -71,6 +72,7 @@ class DoofinderApi
         if (2 === count($zone_key_array)) {
             $this->api_key = $zone_key_array[1];
             $this->zone = $zone_key_array[0];
+            $this->zone = preg_replace('/^https?:\/\//m', '', $this->zone);
             $this->url = "https://" . $this->zone . self::URL_SUFFIX;
         } else {
             throw new DoofinderException("API Key is no properly set.");
@@ -361,9 +363,7 @@ class DoofinderApi
      */
     public function removeTerm($filterName, $term)
     {
-        if ($this->optionExists('filter') && isset($this->search_options['filter'][$filterName])
-            && in_array($term, $this->search_options['filter'][$filterName])
-        ) {
+        if ($this->optionExists('filter') && isset($this->search_options['filter'][$filterName]) && in_array($term, $this->search_options['filter'][$filterName])) {
             function filter_me($value)
             {
                 global $term;
@@ -371,7 +371,7 @@ class DoofinderApi
             }
 
             $this->search_options['filter'][$filterName] =
-            array_filter($this->search_options['filter'][$filterName], 'filter_me');
+                array_filter($this->search_options['filter'][$filterName], 'filter_me');
         }
     }
 

--- a/lib/doofinder_api.php
+++ b/lib/doofinder_api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * NOTICE OF LICENSE
  *
@@ -71,6 +72,7 @@ class DoofinderApi
         if (2 === count($zone_key_array)) {
             $this->api_key = $zone_key_array[1];
             $this->zone = $zone_key_array[0];
+            $this->zone = preg_replace('/^https?:\/\//m', '', $this->zone);
             $this->url = "https://" . $this->zone . self::URL_SUFFIX;
         } else {
             throw new DoofinderException("API Key is no properly set.");
@@ -361,7 +363,8 @@ class DoofinderApi
      */
     public function removeTerm($filterName, $term)
     {
-        if ($this->optionExists('filter') && isset($this->search_options['filter'][$filterName])
+        if (
+            $this->optionExists('filter') && isset($this->search_options['filter'][$filterName])
             && in_array($term, $this->search_options['filter'][$filterName])
         ) {
             function filter_me($value)
@@ -371,7 +374,7 @@ class DoofinderApi
             }
 
             $this->search_options['filter'][$filterName] =
-            array_filter($this->search_options['filter'][$filterName], 'filter_me');
+                array_filter($this->search_options['filter'][$filterName], 'filter_me');
         }
     }
 


### PR DESCRIPTION
It seems that after the latest doomanager update, the connection endpoint is returning a URL including the protocol.
This is causing the region and API key having a wrong format.
I've removed the protocol from the region with a regular expression replacement.