### PR TITLE
Use language code for the installation of the search engines and the layer

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -46,7 +46,7 @@ class Doofinder extends Module
 
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.3.2';
+    const VERSION = '4.3.3';
     const YES = 1;
     const NO = 0;
 
@@ -54,7 +54,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.3.2';
+        $this->version = '4.3.3';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = array('min' => '1.5', 'max' => '1.7');
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/doofinder.php
+++ b/doofinder.php
@@ -1307,7 +1307,7 @@ class Doofinder extends Module
 
     private function configureHookCommon($params = false)
     {
-        $lang = Tools::strtoupper($this->context->language->iso_code);
+        $lang = Tools::strtoupper($this->getLanguageCode($this->context->language->language_code));
         $currency = Tools::strtoupper($this->context->currency->iso_code);
         $search_engine_id = Configuration::get('DF_HASHID_' . $currency . '_' . $lang);
         $df_region = Configuration::get('DF_REGION');
@@ -2544,8 +2544,8 @@ class Doofinder extends Module
         $currencies = Currency::getCurrenciesByIdShop($shop['id_shop']);
         $shopId = $shop['id_shop'];
         $shopGroupId = $shop['id_shop_group'];
-        $primary_lang_id = Configuration::get('PS_LANG_DEFAULT', null, $shopGroupId, $shopId);
-        $primary_language_iso_code = Language::getIsoById($primary_lang_id);
+        $primary_lang = new Language(Configuration::get('PS_LANG_DEFAULT', null, $shopGroupId, $shopId));
+        $primary_language_iso_code = $this->getLanguageCode($primary_lang->language_code);
         $installationID = null;
 
         $this->setDefaultShopConfig($shopGroupId, $shopId);
@@ -2560,7 +2560,7 @@ class Doofinder extends Module
         ];
 
         foreach ($languages as $lang) {
-            $liso = $lang['iso_code'];
+            $liso = $this->getLanguageCode($lang['language_code']);
             foreach ($currencies as $cur) {
                 $ciso =  $cur['iso_code'];
                 $feed_url = $this->buildFeedUrl($shopId, $liso, $ciso);
@@ -2753,5 +2753,12 @@ class Doofinder extends Module
             '
             SELECT `iso_code` FROM ' . _DB_PREFIX_ . 'currency WHERE `id_currency` = ' . (int) $id
         );
+    }
+
+    protected function getLanguageCode($code){
+        // $code is in the form of 'xx-YY' where xx is the language code
+        // and 'YY' a country code identifying a variant of the language.
+        $lang_country = explode('-', $code);
+        return $lang_country[0];
     }
 }


### PR DESCRIPTION
I have gone through the whole plugin and there are more uses of the iso_code.
Some will be removed in this issue: #71 
Others will be modified in the development of this issue: #75 