### PR TITLE
Fixed tags issue with slashes

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -46,7 +46,7 @@ class Doofinder extends Module
 
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.3.6';
+    const VERSION = '4.3.7';
     const YES = 1;
     const NO = 0;
 
@@ -54,7 +54,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.3.6';
+        $this->version = '4.3.7';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = array('min' => '1.5', 'max' => '1.7');
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feed.php
+++ b/feed.php
@@ -461,8 +461,8 @@ foreach ($rows as $row) {
         echo dfTools::splitReferences($product_title) . TXT_SEPARATOR;
 
         // TAGS
-        echo dfTools::cleanString($row['tags']);
-
+        echo str_replace(",", "/", dfTools::cleanString(dfTools::escapeSlashes($row['tags'])));
+        
         //ISBN
         if (dfTools::versionGte('1.7.0.0')) {
             echo TXT_SEPARATOR;

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -442,7 +442,7 @@ class DfTools
         pl.meta_title,
         pl.meta_keywords,
         pl.meta_description,
-        GROUP_CONCAT(tag.name SEPARATOR '/') AS tags,
+        GROUP_CONCAT(tag.name SEPARATOR ',') AS tags,
         pl.link_rewrite,
         cl.link_rewrite AS cat_link_rew,
         im.id_image,
@@ -504,7 +504,7 @@ class DfTools
         pl.meta_title,
         pl.meta_keywords,
         pl.meta_description,
-        GROUP_CONCAT(tag.name SEPARATOR '/') AS tags,
+        GROUP_CONCAT(tag.name SEPARATOR ',') AS tags,
         pl.link_rewrite,
         cl.link_rewrite AS cat_link_rew,
         im.id_image,
@@ -1130,5 +1130,9 @@ class DfTools
     {
         array_walk_recursive($data, array(get_class(), 'walkApplyHtmlEntities'));
         return str_replace("\\/", "/", html_entity_decode(json_encode($data)));
+    }
+
+    public static function escapeSlashes($string){
+        return $string = str_replace("/", "//", $string);
     }
 }

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1132,7 +1132,8 @@ class DfTools
         return str_replace("\\/", "/", html_entity_decode(json_encode($data)));
     }
 
-    public static function escapeSlashes($string){
+    public static function escapeSlashes($string)
+    {
         return $string = str_replace("/", "//", $string);
     }
 }


### PR DESCRIPTION
I've replaced the tags separator in the query with commas in order to escape the slashes originally present in tags.
This way we can escape the slashes in tags with a double slash \\ and finally replace the commas with /

This only affects the feed and now tags are being detected correctly.
![image](https://user-images.githubusercontent.com/1659534/194871649-17e33eed-0ee9-4bcb-a2aa-e54accf111ae.png)

Related Ticket: [https://doofinder.freshdesk.com/a/tickets/83029](https://doofinder.freshdesk.com/a/tickets/83029)
