### PR TITLE
Sofia/update on save empty prices error doof api

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -46,7 +46,7 @@ class Doofinder extends Module
 
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.3.9';
+    const VERSION = '4.3.10';
     const YES = 1;
     const NO = 0;
 
@@ -54,7 +54,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.3.9';
+        $this->version = '4.3.10';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = array('min' => '1.5', 'max' => '1.7');
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/lib/dfProduct_build.php
+++ b/lib/dfProduct_build.php
@@ -278,7 +278,7 @@ class DfProductBuild
         );
 
         if (!$salePrice) {
-            return ($product_price ? Tools::convertPrice($product_price, $this->id_currency) : "");
+            return ($product_price ? Tools::convertPrice($product_price, $this->id_currency) : null);
         } else {
             $onsale_price = Product::getPriceStatic(
                 $product['id_product'],
@@ -288,7 +288,7 @@ class DfProductBuild
             );
 
             return (($product_price && $onsale_price && $product_price != $onsale_price)
-                ? Tools::convertPrice($onsale_price, $this->id_currency) : "");
+                ? Tools::convertPrice($onsale_price, $this->id_currency) : null);
         }
     }
 


### PR DESCRIPTION
We've a bug in the update on save when the price or sale price is empty because doofAPI doesn't accept empty string as a valid value for prices.

Example:
![image](https://user-images.githubusercontent.com/92720455/198694235-2e3bd25a-102c-4635-8ca6-ed5e8228ca66.png)

Instead of empty string we should send null value (that is what we receive during the indexation when there isn't special price specified)
![image](https://user-images.githubusercontent.com/92720455/198694377-e3f2aaf5-423a-470c-bcd6-cd273ba75e3e.png)

![image](https://user-images.githubusercontent.com/92720455/198694711-7e2b6908-bf75-4e05-814e-f3a5686ad7a3.png)



Related ticket: https://doofinder.freshdesk.com/a/tickets/83329
