### PR TITLE
Update on save - Send product features outside of the "attributes" key

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -44,7 +44,7 @@ class Doofinder extends Module
 
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.3.19';
+    const VERSION = '4.3.20';
     const YES = 1;
     const NO = 0;
 
@@ -52,7 +52,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.3.19';
+        $this->version = '4.3.20';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/lib/dfProduct_build.php
+++ b/lib/dfProduct_build.php
@@ -116,7 +116,7 @@ class DfProductBuild
         }
 
         if ($this->show_product_features) {
-            $p['attributes'] = $this->getFeatures($product);
+            $p = array_merge($p, $this->getFeatures($product));
         }
 
         if ($this->product_variations) {
@@ -300,8 +300,12 @@ class DfProductBuild
         $keys = $this->featuresKeys;
 
         foreach (dfTools::getFeaturesForProduct($product['id_product'], $this->id_lang, $keys) as $key => $values) {
-            foreach ($values as $value) {
-                $features[$key][] = dfTools::cleanString($value);
+            if (count($values) > 1) {
+                foreach ($values as $value) {
+                    $features[strtolower($key)][] = dfTools::cleanString($value);
+                }
+            } else {
+                $features[strtolower($key)] = dfTools::cleanString($values[0]);
             }
         }
 


### PR DESCRIPTION
In the update on save the features of the products are being sent inside the "attributes" key:
```json
[
  {
    "id": "2",
    "title": "Hummingbird printed sweater",
    "attributes": {
      "composition": [
        "Algodón",
        "Lana"
      ],
      "property": [
        "Long sleeves"
      ]
    },
    "..."
  }
]
```

With this modification we send them as independent fields, at the root of the product payload. Also, if a feature has only one value, it is not sent in a list:
```json
[
  {
    "id": "2",
    "title": "Hummingbird printed sweater",
    "composition": [
      "Algodón",
      "Lana"
    ],
    "property": "Long sleeves",
    "..."
  }
]
```

