### PR TITLE
Redirection to landings through hashid and slug

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -1625,6 +1625,31 @@ class Doofinder extends Module
     }
 
     /**
+     * Get the language associated with a search engine
+     *
+     * @param bool $hashid
+     *
+     * @return bool|int
+     */
+    public function getLanguageByHashid($hashid)
+    {
+        $result = Db::getInstance()->getValue('
+            SELECT name
+            FROM ' . _DB_PREFIX_ . 'configuration
+            WHERE name like "DF_HASHID_%" and value = "' . pSQL($hashid) . '";
+        ');
+
+        if ($result) {
+            $key = str_replace('DF_HASHID_', '', $result);
+            $iso_code = explode('_', $key)[1];
+
+            return (int) Language::getIdByLocale($iso_code);
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Get the ISO of a currency
      *
      * @param int $id currency ID

--- a/landing.php
+++ b/landing.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This file is licenced under the Software License Agreement.
+ * With the purchase or the installation of the software in your application
+ * you accept the licence agreement.
+ *
+ * You must not modify, adapt or create derivative works of this source code
+ *
+ * @author    Doofinder
+ * @copyright Doofinder
+ * @license   GPLv3
+ */
+require_once dirname(__FILE__) . '/../../config/config.inc.php';
+
+if (Module::isInstalled('doofinder') && Module::isEnabled('doofinder')) {
+    $hashid = Tools::getValue('hashid');
+    $slug = Tools::getValue('slug');
+
+    if ($hashid && $slug) {
+        $module = Module::getInstanceByName('doofinder');
+
+        if ($id_lang = $module->getLanguageByHashid($hashid)) {
+            $link = Context::getContext()->link->getModuleLink(
+                $module->name,
+                'landing',
+                ['landing_name' => $slug],
+                null,
+                $id_lang
+            );
+
+            Tools::redirect($link);
+        }
+    }
+}
+Tools::redirect('index.php?controller=404');


### PR DESCRIPTION
Required by: https://github.com/doofinder/dfcommon/issues/739

**Redirect multi-lang (Considering the SE language):**
doofinder.shop/modules/doofinder/landing.php?slug=XXX&hashid=YYY -> doofinder.shop/en/df/XXX
**Redirect without multi-lang:** 
doofinder.shop/modules/doofinder/landing.php?slug=XXX&hashid=YYY -> doofinder.shop/df/XXX