### PR TITLE
UNPLUGGED-141 | Added guard clause to prevent update on empty payload

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -1214,6 +1214,10 @@ class Doofinder extends Module
 
     private function updateItemsApi($hashid, $type, $payload)
     {
+        if (empty($payload)) {
+            return;
+        }
+
         require_once dirname(__FILE__) . '/lib/doofinder_api_items.php';
 
         $apikey = explode('-', Configuration::get('DF_API_KEY'))[1];
@@ -1229,6 +1233,10 @@ class Doofinder extends Module
 
     private function deleteItemsApi($hashid, $type, $payload)
     {
+        if (empty($payload)) {
+            return;
+        }
+
         require_once dirname(__FILE__) . '/lib/doofinder_api_items.php';
 
         $apikey = explode('-', Configuration::get('DF_API_KEY'))[1];


### PR DESCRIPTION
Required by: https://github.com/doofinder/doofinder-prestashop/issues/141

Due to a very large query at low level, even if there are products to update, the payload might be empty on certain situations. Since debugging this huge query that was made 5 years ago can be a very hard task, the best solution is add a guard in the case the payload is empty, since this edge-case was causing some sentries: https://doofindercom.sentry.io/issues/4275981407/?project=6152838

Since on deletion it makes no sense at all to send a request with an empty payload, the same solution has been applied to this part.