### PR TITLE
UNPLUGGED-81 | Added a way to launch feed reprocessing after changing the settings

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -35,7 +35,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.6.5';
+    const VERSION = '4.7.0';
     const YES = 1;
     const NO = 0;
 
@@ -43,7 +43,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.6.5';
+        $this->version = '4.7.0';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/doofinder.php
+++ b/doofinder.php
@@ -1260,7 +1260,7 @@ class Doofinder extends Module
         require_once dirname(__FILE__) . '/lib/doofinder_api_index.php';
 
         $region = Configuration::get('DF_REGION');
-        $api_key = $region . '-' . Configuration::get('DF_AI_APIKEY');
+        $api_key = Configuration::get('DF_API_KEY');
         $api = new DoofinderApiIndex($api_key, $region);
         $response = $api->invokeReindexing(Configuration::get('DF_INSTALLATION_ID'), $this->getProcessCallbackUrl());
         if (empty($response)) {

--- a/lib/doofinder_api_index.php
+++ b/lib/doofinder_api_index.php
@@ -15,49 +15,30 @@
 require_once _PS_MODULE_DIR_ . 'doofinder/lib/EasyREST.php';
 
 const API_URL = 'https://{region}-admin.doofinder.com';
-const API_VERSION = '2';
+const API_VERSION = '1';
 
-class DoofinderApiItems
+class DoofinderApiIndex
 {
-    private $hashid;
     private $api_key;
     private $api_url;
-    private $type;
 
-    public function __construct($hashid, $api_key, $region, $type = 'product')
+    public function __construct($api_key, $region)
     {
-        $this->hashid = $hashid;
         $this->api_key = $api_key;
         $this->api_url = str_replace('{region}', $region, API_URL);
-        $this->type = $type;
     }
 
     /**
-     * Make a request to the API to update the specified items
+     * Make a request to the API to reprocess all the feeds
      *
-     * @param array items data
+     * @param string $installation_id
+     * @param string $callback_url
      */
-    public function updateBulk($payload)
+    public function invokeReindexing($installation_id, $callback_url = '')
     {
-        $endpoint = '/plugins/prestashop/' . $this->hashid . '/' . $this->type . '/product_update';
+        $json_data = json_encode(['query' => 'mutation { process_store_feeds(id: "' . $installation_id . '", callback_url: "' . $callback_url . '") { id }}']);
 
-        $url = $this->api_url . $endpoint;
-
-        return $this->post($url, $payload);
-    }
-
-    /**
-     * Make a request to the API to delete the specified items
-     *
-     * @param array items ids
-     */
-    public function deleteBulk($payload)
-    {
-        $endpoint = '/plugins/prestashop/' . $this->hashid . '/' . $this->type . '/product_delete';
-
-        $url = $this->api_url . $endpoint;
-
-        return $this->post($url, $payload);
+        return $this->post(sprintf('%1$s/api/v%2$s/graphql.json', $this->api_url, API_VERSION), $json_data);
     }
 
     private function post($url, $payload)

--- a/lib/doofinder_api_items.php
+++ b/lib/doofinder_api_items.php
@@ -19,11 +19,6 @@ const API_VERSION = '2';
 
 class DoofinderApiItems
 {
-    private $hashid;
-    private $api_key;
-    private $api_url;
-    private $type;
-
     public function __construct($hashid, $api_key, $region, $type = 'product')
     {
         $this->hashid = $hashid;

--- a/lib/doofinder_api_items.php
+++ b/lib/doofinder_api_items.php
@@ -19,7 +19,6 @@ const API_VERSION = '2';
 
 class DoofinderApiItems
 {
-
     private $hashid;
     private $api_key;
     private $api_url;

--- a/views/templates/admin/display_msg.tpl
+++ b/views/templates/admin/display_msg.tpl
@@ -14,7 +14,9 @@
 <div class="bootstrap">
     <div class="module_{$d_type_message|escape:'htmlall':'UTF-8'} alert alert-{$d_type_alert|escape:'htmlall':'UTF-8'}" >
         <button type="button" class="close" data-dismiss="alert">&times;</button>
-        {if isset($d_link) && $d_link}
+        {if isset($d_raw) && $d_raw}
+            {$d_message|unescape:'html'}
+        {elseif isset($d_link) && $d_link}
             <a href="{$d_link|escape:'htmlall':'UTF-8'}">
             {$d_message|escape:'htmlall':'UTF-8'}
             </a>


### PR DESCRIPTION
Required by: https://github.com/doofinder/doofinder-prestashop/issues/81 and cannot be deployed before this one is deployed: https://github.com/doofinder/doomanager/pull/4522.  

This issue consists on two main parts: one is included in the other PR, which involves the creation of an endpoint in GraphQL on DooManager and the other part is this one which consists on calling the endpoint after clicking the "launch reindexing" button in Prestashop.


![prestashop-reindex](https://github.com/doofinder/doofinder-prestashop/assets/128705267/3bb6a2b9-e9e7-4e63-9a34-d55d6268c9bd)

IMPORTANT: @CristobalDolz and the support team have to test the plugin before deploying it to the general public
