### PR TITLE
Improve category separator in feed

### DIFF
--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -12,7 +12,7 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-define('CATEGORY_SEPARATOR', '%%');
+define('CATEGORY_SEPARATOR', ' %% ');
 define('CATEGORY_TREE_SEPARATOR', '>');
 define('TXT_SEPARATOR', '|');
 


### PR DESCRIPTION
In the case of having categories "offer 50%" and "shoes", it currently appears like this in the feed:
`offer50%%%Shoes`
So there is conflict when indexing with the category separator.

With this change it will be like this:
`offer50% %% Shoes`


Required by https://github.com/doofinder/support/issues/1144
