### PR TITLE
UNPLUGGED-912 | Added support for multiple blocks in the landings

### DIFF
--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -44,8 +44,12 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
             Tools::redirect('index.php?controller=404');
         }
 
-        if ($products_result = $this->module->searchOnApi($this->landing_data['query'], 1, self::RESULTS)) {
-            $this->products = $products_result['result'];
+        foreach ($this->landing_data['blocks'] as $block) {
+            if ($products_result = $this->module->searchOnApi($block['query'], 1, self::RESULTS)) {
+                $this->products[] = $products_result['result'];
+            } else {
+                $this->products[] = [];
+            }
         }
     }
 
@@ -83,20 +87,23 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
             $this->context->getTranslator()
         );
 
-        $products = [];
-        foreach ($this->products as $productDetail) {
-            $products[] = $presenter->present(
-                $presentationSettings,
-                $assembler->assembleProduct($productDetail),
-                $this->context->language
-            );
+        $products_length = count($this->products);
+        for ($i = 0; $i < $products_length; ++$i) {
+            $products = [];
+            foreach ($this->products[$i] as $productDetail) {
+                $products[] = $presenter->present(
+                    $presentationSettings,
+                    $assembler->assembleProduct($productDetail),
+                    $this->context->language
+                );
+            }
+            $this->landing_data['blocks'][$i]['products'] = $products;
         }
 
         $this->context->smarty->assign(
             [
-                'products' => $products,
+                'blocks' => $this->landing_data['blocks'],
                 'title' => $this->landing_data['title'],
-                'description' => $this->landing_data['description'],
             ]
         );
 
@@ -105,11 +112,14 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
     private function renderProductList16()
     {
+        $products_length = count($this->products);
+        for ($i = 0; $i < $products_length; ++$i) {
+            $this->landing_data['blocks'][$i]['products'] = $this->products[$i];
+        }
         $this->context->smarty->assign(
             [
-                'search_products' => $this->products,
+                'blocks' => $this->landing_data['blocks'],
                 'title' => $this->landing_data['title'],
-                'description' => $this->landing_data['description'],
                 'meta_title' => $this->landing_data['meta_title'],
                 'meta_description' => $this->landing_data['meta_description'],
                 'nobots' => $this->landing_data['index'] ? false : true,
@@ -158,12 +168,22 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
             $data = [
                 'title' => $response['title'],
-                'description' => $response['description'],
                 'meta_title' => $response['meta_title'],
                 'meta_description' => $response['meta_description'],
                 'index' => $response['index'],
-                'query' => $response['query'],
             ];
+
+            if (is_array($response['blocks']) && count($response['blocks']) > 0) {
+                $data['blocks'] = [];
+                foreach ($response['blocks'] as $block) {
+                    $data['blocks'][] = [
+                        'above' => base64_decode($block['above']),
+                        'below' => base64_decode($block['below']),
+                        'position' => $block['position'],
+                        'query' => $block['query'],
+                    ];
+                }
+            }
 
             $this->setLandingCache($name, $hashid, base64_encode(json_encode($data)));
 

--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -111,10 +111,6 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
     private function renderProductList16()
     {
-        $products_length = count($this->products);
-        for ($i = 0; $i < $products_length; ++$i) {
-            $this->landing_data['blocks'][$i]['products'] = $this->products[$i];
-        }
         $this->context->smarty->assign(
             [
                 'blocks' => $this->landing_data['blocks'],

--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -87,17 +87,18 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
             $this->context->getTranslator()
         );
 
-        $products_length = count($this->products);
-        for ($i = 0; $i < $products_length; ++$i) {
+        $blocks_count = 0;
+        foreach ($this->products as $product) {
             $products = [];
-            foreach ($this->products[$i] as $productDetail) {
+            foreach ($product as $productDetail) {
                 $products[] = $presenter->present(
                     $presentationSettings,
                     $assembler->assembleProduct($productDetail),
                     $this->context->language
                 );
             }
-            $this->landing_data['blocks'][$i]['products'] = $products;
+            $this->landing_data['blocks'][$blocks_count]['products'] = $products;
+            ++$blocks_count;
         }
 
         $this->context->smarty->assign(

--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -44,11 +44,11 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
             Tools::redirect('index.php?controller=404');
         }
 
-        foreach ($this->landing_data['blocks'] as $block) {
+        foreach ($this->landing_data['blocks'] as &$block) {
             if ($products_result = $this->module->searchOnApi($block['query'], 1, self::RESULTS)) {
-                $this->products[] = $products_result['result'];
+                $block['products'] = $products_result['result'];
             } else {
-                $this->products[] = [];
+                $block['products'] = [];
             }
         }
     }
@@ -87,18 +87,16 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
             $this->context->getTranslator()
         );
 
-        $blocks_count = 0;
-        foreach ($this->products as $product) {
+        foreach ($this->landing_data['blocks'] as &$block) {
             $products = [];
-            foreach ($product as $productDetail) {
+            foreach ($block['products'] as $productDetail) {
                 $products[] = $presenter->present(
                     $presentationSettings,
                     $assembler->assembleProduct($productDetail),
                     $this->context->language
                 );
             }
-            $this->landing_data['blocks'][$blocks_count]['products'] = $products;
-            ++$blocks_count;
+            $block['products'] = $products;
         }
 
         $this->context->smarty->assign(
@@ -188,7 +186,7 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
             $this->setLandingCache($name, $hashid, base64_encode(json_encode($data)));
 
-            return $response;
+            return $data;
         }
     }
 

--- a/doofinder.php
+++ b/doofinder.php
@@ -35,7 +35,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.0';
+    const VERSION = '4.7.1';
     const YES = 1;
     const NO = 0;
 
@@ -43,7 +43,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.0';
+        $this->version = '4.7.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/doofinder.php
+++ b/doofinder.php
@@ -35,7 +35,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.1';
+    const VERSION = '4.7.2';
     const YES = 1;
     const NO = 0;
 
@@ -43,7 +43,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.1';
+        $this->version = '4.7.2';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -66,26 +66,26 @@ class DfTools
     // SQL Queries
 
     /**
-     * Returns an array of image size names to be used in a <select> box.
+     * Returns an array of image size names to be used in a <select> box. Array (assoc) with the value of each key as value for it
      *
-     * @return array (assoc) with the value of each key as value for it
+     * @return array
      */
     public static function getAvailableImageSizes()
     {
         $sizes = [];
         $sql = "
-      SELECT
-        `name` AS DF_GS_IMAGE_SIZE,
-        `name`
-      FROM
-        `_DB_PREFIX_image_type`
-      WHERE
-        `products` = 1
-      ORDER BY
-        CASE
-            WHEN name = 'home_default' THEN '1'
-        END DESC;
-    ";
+        SELECT
+            `name` AS DF_GS_IMAGE_SIZE,
+            `name`
+        FROM
+            `_DB_PREFIX_image_type`
+        WHERE
+            `products` = 1
+        ORDER BY
+            CASE
+                WHEN name = 'home_default' THEN '1'
+            END DESC;
+        ";
 
         foreach (Db::getInstance()->ExecuteS(self::prepareSQL($sql)) as $size) {
             $sizes[$size['DF_GS_IMAGE_SIZE']] = $size;

--- a/lib/doofinder_api_landing.php
+++ b/lib/doofinder_api_landing.php
@@ -32,7 +32,7 @@ class DoofinderApiLanding
      */
     public function getLanding($slug)
     {
-        $endpoint = '/plugins/landing/' . $this->hashid . '/' . $slug;
+        $endpoint = '/plugins/landing_new/' . $this->hashid . '/' . $slug;
 
         $url = $this->api_url . $endpoint;
 

--- a/upgrade/upgrade-4.7.1.php
+++ b/upgrade/upgrade-4.7.1.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * 2007-2022 PrestaShop SA and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2022 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_4_7_1($module)
+{
+    return Db::getInstance()->delete('doofinder_landing');
+}

--- a/upgrade/upgrade-4.7.2.php
+++ b/upgrade/upgrade-4.7.2.php
@@ -27,7 +27,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-function upgrade_module_4_7_1($module)
+function upgrade_module_4_7_2($module)
 {
     return Db::getInstance()->delete('doofinder_landing');
 }

--- a/views/templates/front/landing.tpl
+++ b/views/templates/front/landing.tpl
@@ -16,29 +16,34 @@
 
 {block name='content'}
     <div class="container">
-        <section class="page_content mb-1">
+        <section class="page_content mb-1 card card-block">
             <div id="js-product-list-header">
-                <div class="block-category card card-block">
-                    <h1 class="h1">{$title|escape:'html':'UTF-8'}</h1>
-                    <div class="block-category-inner">
-                        <div id="category-description" class="text-muted">{$description|escape:'html':'UTF-8'}</div>
-                    </div>
+                <div class="mb-2 mt-2">
+                    <h1 class="h1 text-center text-xs-center">{$title|escape:'html':'UTF-8'}</h1>
                 </div>
             </div>
 
             <section id="products">
-                {if $products|count}
-                    {include file="catalog/_partials/productlist.tpl" products=$products cssClass="row" productClass="col-xs-6 col-xl-3"}
-                {else}
-                    <div id="js-product-list">
-                      {capture assign="errorContent"}
-                        <h4>{l s='No products available yet' d='Shop.Theme.Catalog'}</h4>
-                        <p>{l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}</p>
-                      {/capture}
+                {foreach $blocks as $block}
+                    {if $block['products']|count}
+                        <div class="mb-1 mt-2 df-block-above">
+                            {$block['above']|cleanHtml nofilter}
+                        </div>
+                        {include file="catalog/_partials/productlist.tpl" products=$block['products'] cssClass="row" productClass="col-xs-6 col-xl-3"}
+                        <div class="mb-2 mt-1 df-block-below">
+                            {$block['below']|cleanHtml nofilter}
+                        </div>
+                    {else}
+                        <div id="js-product-list">
+                        {capture assign="errorContent"}
+                            <h4>{l s='No products available yet' d='Shop.Theme.Catalog'}</h4>
+                            <p>{l s='Stay tuned! More products will be shown here as they are added.' d='Shop.Theme.Catalog'}</p>
+                        {/capture}
 
-                      {include file='errors/not-found.tpl' errorContent=$errorContent}
-                    </div>
-                {/if}
+                        {include file='errors/not-found.tpl' errorContent=$errorContent}
+                        </div>
+                    {/if}
+                {/foreach}
             </section>
         </section>
     </div>

--- a/views/templates/front/landing16.tpl
+++ b/views/templates/front/landing16.tpl
@@ -14,8 +14,17 @@
 
 
 {include file="$tpl_dir./errors.tpl"}
-<h1 class="page-heading product-listing">{$title|escape:'html':'UTF-8'}</h1>
-<div class="block-category-inner">
-    <div id="category-description" class="text-muted">{$description|escape:'html':'UTF-8'}</div>
+<h1 class="page-heading product-listing text-center">{$title|escape:'html':'UTF-8'}</h1>
+<div>
+    {foreach $blocks as $block}
+        {if $block['products']|count}
+            <div class="df-block-above main-page-indent">
+                {$block['above']|cleanHtml nofilter}
+            </div>
+            {include file="$tpl_dir./product-list.tpl" products=$block['products']}
+            <div class="df-block-below main-page-indent">
+                {$block['below']|cleanHtml nofilter}
+            </div>
+        {/if}
+    {/foreach}
 </div>
-{include file="$tpl_dir./product-list.tpl" products=$search_products}


### PR DESCRIPTION
Required by: https://github.com/doofinder/dfcommon/issues/912

Until now, the landings could only have a single block. With the new endpoint from Doomanager, it's possible to create several blocks, so the plugin has been adapted to be able to handle multiple blocks.

PS: There was a bug at the moment of taking the screenshots where the search queries were duplicated from the endpoint itself. That's why it shows the same results in all the blocks: This bug will be solved in this PR: https://github.com/doofinder/doomanager/pull/5022

PS 1.6.x or lower

![image](https://github.com/doofinder/doofinder-prestashop/assets/128705267/a380747b-fc23-4af7-9526-b2c3af2fcfb5)

PS 1.7.x or higher

![image](https://github.com/doofinder/doofinder-prestashop/assets/128705267/44b50d46-eb4a-4b1c-a6d1-08a04e47ff9e)
