### PR TITLE
Fixed is_mobile error

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -1978,7 +1978,7 @@ class Doofinder extends Module
         $context = Context::getContext();
         // In certain older PrestaShop 1.6 versions, the 'isMobile' method may not be directly available within the context.
         // To address this, we check for the method's existence and, if absent, fall back on the 'getMobileDetect' version as an alternative.
-        $isMobile = method_exists($context, "isMobile") ? $context->isMobile() : $context->getMobileDetect()->isMobile();
+        $isMobile = method_exists($context, 'isMobile') ? $context->isMobile() : $context->getMobileDetect()->isMobile();
 
         return ($isMobile && $displayMobile) || (!$isMobile && $displayDesktop);
     }

--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.21';
+    const VERSION = '4.7.22';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.21';
+        $this->version = '4.7.22';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/doofinder.php
+++ b/doofinder.php
@@ -1975,7 +1975,10 @@ class Doofinder extends Module
     {
         $displayMobile = Configuration::get('DF_SHOW_LAYER_MOBILE', null, null, null, true);
         $displayDesktop = Configuration::get('DF_SHOW_LAYER', null, null, null, true);
-        $isMobile = Context::getContext()->isMobile();
+        $context = Context::getContext();
+        // In certain older PrestaShop 1.6 versions, the 'isMobile' method may not be directly available within the context.
+        // To address this, we check for the method's existence and, if absent, fall back on the 'getMobileDetect' version as an alternative.
+        $isMobile = method_exists($context, "isMobile") ? $context->isMobile() : $context->getMobileDetect()->isMobile();
 
         return ($isMobile && $displayMobile) || (!$isMobile && $displayDesktop);
     }

--- a/lib/EasyREST.php
+++ b/lib/EasyREST.php
@@ -391,7 +391,7 @@ class EasyREST
      */
     public static function get(
         $url,
-        ?array $params = null,
+        $params = null,
         $user = null,
         $pwd = null,
         $contentType = 'multipart/form-data',

--- a/lib/EasyREST.php
+++ b/lib/EasyREST.php
@@ -391,7 +391,7 @@ class EasyREST
      */
     public static function get(
         $url,
-        array $params = null,
+        ?array $params = null,
         $user = null,
         $pwd = null,
         $contentType = 'multipart/form-data',

--- a/views/templates/admin/display_msg.tpl
+++ b/views/templates/admin/display_msg.tpl
@@ -15,7 +15,7 @@
     <div class="module_{$d_type_message|escape:'htmlall':'UTF-8'} alert alert-{$d_type_alert|escape:'htmlall':'UTF-8'}" >
         <button type="button" class="close" data-dismiss="alert">&times;</button>
         {if isset($d_raw) && $d_raw}
-            {$d_message|unescape:'html'}
+            {html_entity_decode($d_raw|escape:'htmlall':'UTF-8')}            
         {elseif isset($d_link) && $d_link}
             <a href="{$d_link|escape:'htmlall':'UTF-8'}">
             {$d_message|escape:'htmlall':'UTF-8'}


### PR DESCRIPTION
Required-by:
- https://github.com/doofinder/support/issues/2086

In certain older PrestaShop 1.6 versions, the `isMobile()` method may not be directly available within the context. To address this, we check for the method's existence and, if absent, fall back on the `getMobileDetect()` method as an alternative.