### PR TITLE
Set default country in product feed

### DIFF
--- a/feeds/product.php
+++ b/feeds/product.php
@@ -106,6 +106,8 @@ if (!$shop->id) {
 // CONFIG
 $lang = dfTools::getLanguageFromRequest();
 $context->language = $lang;
+$country = Configuration::get('PS_COUNTRY_DEFAULT');
+$context->country = new Country($country);
 $currency = dfTools::getCurrencyForLanguageFromRequest($lang);
 
 $cfg_short_description = (dfTools::cfg(


### PR DESCRIPTION
Prices are prevented from being obtained from the geo-located country (Ireland in our case).
Prices are obtained from the country that is configured as default.