### PR TITLE
Update docker volume and readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ vendor/
 composer.lock
 .php-cs-fixer.dist.php
 .php-cs-fixer.cache
+/html

--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ To choose the prestashop version, in the container image change:
 - **prestashop/prestashop:1.7** for version 1.7
 - **prestashop/prestashop:latest** for the latest available version of prestashop
 
-Once the environment is installed, move the module files to `/modules/doofinder`.
+You can now visit `localhost:9000` to start the prestashop installation
+To install prestashop, follow the steps in the wizard.
+Notice that when asked to configure the database connection you should use the following fields as are defined in the `docker-compos.yml`
+- url: `local-prestashop-mysql`
+- database: `prestashop`
+- user: `prestashop`
+- password: `prestashop`
+
+Remember to test the database connection to confirm is working.
+
+After the installation is finished you should remove the install folder to start using the app.
+`docker-compose exec prestashop rm -r install`
+
 ## How to install
 
 The easiest way of installing the plugin is downloading it from our [support page](http://www.doofinder.com/support). If you want to download it from this page, you can download the latest release from the tags section, but you will have to prepare the module `.zip` file prior to installing it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,14 @@ services:
       - 9000:80
       - 443:443
     environment:
+      APACHE_RUN_USER: '#1000'
+      APACHE_RUN_GROUP: '#1000'
       PS_DB_HOST: db:3306
       PS_DB_USER: prestashop
       PS_DB_PASSWORD: prestashop
     volumes:
       - ./html:/var/www/html
+      - ./:/var/www/html/modules/doofinder
     container_name: local-web-prestashop
 volumes:
   data:


### PR DESCRIPTION
Required By
https://github.com/doofinder/doofinder-prestashop/issues/186

Update Docker Volume to include the plugin automatically and make apache run with the linux user (1000:1000) so the owner doesn't need to change.
Also explain how to install prestashop in the readme