### PR TITLE
Update database and web port to 3311/9011

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Plugin that allows to configure the [Doofinder](http://www.doofinder.com) search
 For a local installation of a prestashop environment use `docker-compose up -d`. 
 This installation brings: 
 
-- **a mysql container** for the database (on port 3308)
-- **a prestashop container** (in which you can choose the version to install) on port 9000
+- **a mysql container** for the database (on port 3311)
+- **a prestashop container** (in which you can choose the version to install) on port 9011
 
 To choose the prestashop version, in the container image change:
 
@@ -16,7 +16,7 @@ To choose the prestashop version, in the container image change:
 - **prestashop/prestashop:1.7** for version 1.7
 - **prestashop/prestashop:latest** for the latest available version of prestashop
 
-You can now visit `localhost:9000` to start the prestashop installation
+You can now visit `localhost:9011` to start the prestashop installation
 To install prestashop, follow the steps in the wizard.
 Notice that when asked to configure the database connection you should use the following fields as are defined in the `docker-compose.yml`
 - url: `local-prestashop-mysql`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_PASSWORD: prestashop
       MYSQL_ROOT_PASSWORD: prestashop
     ports:
-      - 3308:3306
+      - 3311:3306
     container_name: local-prestashop-mysql
 
   prestashop:
@@ -19,7 +19,7 @@ services:
       - db
     image: prestashop/prestashop:1.7
     ports:
-      - 9000:80
+      - 9011:80
       - 443:443
     environment:
       APACHE_RUN_USER: '#1000'


### PR DESCRIPTION
The port 3308 is already used by another service of the megascript dockers (dfsubscriptions) and now that we're updating the docker environments on these projects I thought it would be a good idea to use similar ports for each project (PE: 3310 instead of 3308 and 9010 instead of 9000
Therefore is easier for us (working with different platforms at the same time) to know which db port corresponds to which service and the ports are ordered somehow, instead of using 9000 here and 4000 on wordpress we can use 9010 and forward to have them running in ordered ports.