### PR TITLE
Add missing static_token

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -872,6 +872,8 @@ class Doofinder extends Module
             );
         }
 
+        $this->context->smarty->assign('static_token', Tools::getToken(false));
+
         return $this->display(__FILE__, 'views/templates/front/scriptV9.tpl');
     }
 


### PR DESCRIPTION
We have tons of these messages in our logs:
```
PHP Notice:  Undefined index: static_token in /var/www/example.com/cache/smarty/compile/e5/ed/c0/e5edc08ed19c8b0b839ebdaad176a065d699ae8d.file.scriptV9.tpl.php on line 68
```

Initially we figured it was because of an old version `abandonedcarts` module with a cron controller that didn't run `initHeader()` but ran `initContent()`, causing the issue, but now we see the problem again and we didn't see the cause. Should this fix all our troubles?