### PR TITLE
Clean pipes in product feed

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.25';
+    const VERSION = '4.7.26';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.25';
+        $this->version = '4.7.26';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1088,6 +1088,7 @@ class DfTools
         $text = trim($text);
         $text = preg_replace('/^["\']+/', '', $text); // remove first quotes
         $text = str_replace(TXT_SEPARATOR, '&#124;', $text);
+
         return preg_replace(self::VALID_UTF8, '$1', $text);
     }
 

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -461,6 +461,7 @@ class DfTools
         $Shop = new Shop($id_shop);
 
         $isbn = '';
+        $isbn_pa = '';
         if (dfTools::versionGte('1.7.0.0')) {
             $isbn = 'p.isbn,';
             if (dfTools::cfg($id_shop, 'DF_SHOW_PRODUCT_VARIATIONS') == 1) {
@@ -1039,6 +1040,7 @@ class DfTools
         $text = trim($text);
         $text = preg_replace("/\r|\n/", '', $text);
         $text = explode('?', $text);
+        $text = str_replace(TXT_SEPARATOR, '%7C', $text);
 
         $baseUrl = [];
         foreach (explode('/', $text[0]) as $part) {
@@ -1080,7 +1082,7 @@ class DfTools
         }
 
         $text = preg_replace('/[^\P{C}]+/u', ' ', $text);
-        $text = str_replace(TXT_SEPARATOR, '-', $text);
+        $text = str_replace(TXT_SEPARATOR, '%7C', $text);
         $text = str_replace(["\t", "\r", "\n"], ' ', $text);
         $text = self::stripHtml($text);
         $text = preg_replace('/\s+/', ' ', $text);

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1082,13 +1082,12 @@ class DfTools
         }
 
         $text = preg_replace('/[^\P{C}]+/u', ' ', $text);
-        $text = str_replace(TXT_SEPARATOR, '%7C', $text);
         $text = str_replace(["\t", "\r", "\n"], ' ', $text);
         $text = self::stripHtml($text);
         $text = preg_replace('/\s+/', ' ', $text);
         $text = trim($text);
         $text = preg_replace('/^["\']+/', '', $text); // remove first quotes
-
+        $text = str_replace(TXT_SEPARATOR, "&#124;", $text);
         return preg_replace(self::VALID_UTF8, '$1', $text);
     }
 

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1087,7 +1087,7 @@ class DfTools
         $text = preg_replace('/\s+/', ' ', $text);
         $text = trim($text);
         $text = preg_replace('/^["\']+/', '', $text); // remove first quotes
-        $text = str_replace(TXT_SEPARATOR, "&#124;", $text);
+        $text = str_replace(TXT_SEPARATOR, '&#124;', $text);
         return preg_replace(self::VALID_UTF8, '$1', $text);
     }
 


### PR DESCRIPTION
## Required by

- https://github.com/doofinder/support/issues/2221

## What's changed

- The pipe character "|" has been replaced by its code representation both in title and link fields of the product feed
- Initialized `$isbn_pa` variable.