### PR TITLE
PLUGINRANGERS-2307 | Added more checks to cover some special cases during Conversion Pages retrieval

### DIFF
--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -192,7 +192,8 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
     private function getApiCall($name, $hashid)
     {
-        $apikey = explode('-', Configuration::get('DF_API_KEY'))[1];
+        $apikey = explode('-', Configuration::get('DF_API_KEY'));
+        $apikey = end($apikey);
         $region = Configuration::get('DF_REGION');
 
         $api = new DoofinderApiLanding($hashid, $apikey, $region);

--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.27';
+    const VERSION = '4.7.28';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.27';
+        $this->version = '4.7.28';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
@@ -1402,7 +1402,8 @@ class Doofinder extends Module
             $product_pool_attributes = [];
             $product_pool_ids = [];
             foreach ($dfResultsArray as $entry) {
-                if ($entry['type'] == 'product') {
+                // For unknown reasons, it can sometimes be defined as 'products' in plural
+                if (in_array($entry['type'], ['product', 'products'])) {
                     if (strpos($entry['id'], 'VAR-') === false) {
                         $product_pool_ids[] = (int) pSQL($entry['id']);
                     } else {
@@ -1840,11 +1841,14 @@ class Doofinder extends Module
      */
     public function getLanguageIdByLocale($locale)
     {
+        $sanitized_locale = pSQL(strtolower($locale));
+
         return Db::getInstance()
             ->getValue(
                 'SELECT `id_lang` FROM `' . _DB_PREFIX_ . 'lang`
-                WHERE `locale` = \'' . pSQL(strtolower($locale)) . '\'
-                OR `language_code` = \'' . pSQL(strtolower($locale)) . '\''
+                WHERE `locale` = \'' . $sanitized_locale . '\'
+                OR `language_code` = \'' . $sanitized_locale . '\'
+                OR `iso_code` = \'' . $sanitized_locale . '\''
             );
     }
 

--- a/lib/doofinder_api.php
+++ b/lib/doofinder_api.php
@@ -64,20 +64,13 @@ class DoofinderApi
      *                             -'apiVersion' (default: '4')=> the api of the search server to query
      *                             -'restrictedRequest'(default: $_REQUEST):  =>restrict request object
      *                             to look for params when unserializing. either 'get' or 'post'
-     *
-     * @throws DoofinderException if $hashid is not a md5 hash or api is no 4, 3.0 or 1.0
      */
     public function __construct($hashid, $api_key, $fromParams = false, $init_options = [])
     {
         $zone_key_array = explode('-', $api_key);
-
-        if (2 === count($zone_key_array)) {
-            $this->api_key = $zone_key_array[1];
-            $this->zone = $zone_key_array[0];
-            $this->url = 'https://' . $this->zone . self::URL_SUFFIX;
-        } else {
-            throw new DoofinderException('API Key is no properly set.');
-        }
+        $this->api_key = end($zone_key_array);
+        $this->zone = Configuration::get('DF_REGION');
+        $this->url = 'https://' . $this->zone . self::URL_SUFFIX;
 
         if (array_key_exists('prefix', $init_options)) {
             $this->paramsPrefix = $init_options['prefix'];


### PR DESCRIPTION
Required by: 

- https://github.com/doofinder/support/issues/2307

This PR adapts the code to cover some special cases:
- The id_lang was being retrieved by comparing the locale against locale or language_code; however, it's better to use the iso_code since it always returns the local as a 2-chars entity.
- It was being assumed that the API Key will always have the following structure: region-apikey (separated by a hyphen), which isn't always true because this customer https://vybaveni-hotelu.cz had the API Key defined as the apikey without the region part within it. Instead of assuming there will be 2 parts, we are always retrieving the final one by using `end()` function thus avoiding fatal errors. The region is retrieved from the ps_config instead, which is a better way.
- For some reason, the key of the products is generally 'product'. Nervertheless, in some cases like this customer's Prestashop, it's defined as 'products' in plural.

After applying this fix to the customer's Prestashop using FTP, it seems to work as expected while not affecting the ones which were working previously:

![image](https://github.com/doofinder/doofinder-prestashop/assets/128705267/1a37b53e-0fbd-4c39-971e-fd736c492204)
