### PR TITLE
PLUGINRANGERS-2312 | Improved path traversing when there are symlinks in the Prestashop CMS

### DIFF
--- a/cache.php
+++ b/cache.php
@@ -12,7 +12,13 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-require_once dirname(__FILE__) . '/../../config/config.inc.php';
+$root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+} else {
+    require_once dirname(__FILE__) . '/../../config/config.inc.php';
+}
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/config.php
+++ b/config.php
@@ -12,8 +12,15 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-require_once dirname(__FILE__) . '/../../config/config.inc.php';
-require_once dirname(__FILE__) . '/../../init.php';
+$root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+    require_once $root_path . '/init.php';
+} else {
+    require_once dirname(__FILE__) . '/../../config/config.inc.php';
+    require_once dirname(__FILE__) . '/../../init.php';
+}
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/doofinder-ajax.php
+++ b/doofinder-ajax.php
@@ -12,8 +12,15 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-require_once dirname(__FILE__) . '/../../config/config.inc.php';
-require_once dirname(__FILE__) . '/../../init.php';
+$root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+    require_once $root_path . '/init.php';
+} else {
+    require_once dirname(__FILE__) . '/../../config/config.inc.php';
+    require_once dirname(__FILE__) . '/../../init.php';
+}
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.28';
+    const VERSION = '4.7.29';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.28';
+        $this->version = '4.7.29';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feed.php
+++ b/feed.php
@@ -14,7 +14,6 @@
  */
 $root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
 $config_file_path = $root_path . '/config/config.inc.php';
-echo $config_file_path;
 if (file_exists($config_file_path)) {
     require_once $config_file_path;
 } else {

--- a/feed.php
+++ b/feed.php
@@ -12,7 +12,14 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-require_once dirname(__FILE__) . '/../../config/config.inc.php';
+$root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+$config_file_path = $root_path . '/config/config.inc.php';
+echo $config_file_path;
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+} else {
+    require_once dirname(__FILE__) . '/../../config/config.inc.php';
+}
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/feeds/category.php
+++ b/feeds/category.php
@@ -16,7 +16,14 @@ if (function_exists('set_time_limit')) {
     @set_time_limit(3600 * 2);
 }
 
-require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+$root_path = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+} else {
+    require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+}
+
 require_once dirname(__FILE__) . '/../lib/dfCategory_build.php';
 
 if (!defined('_PS_VERSION_')) {

--- a/feeds/cms.php
+++ b/feeds/cms.php
@@ -16,7 +16,14 @@ if (function_exists('set_time_limit')) {
     @set_time_limit(3600 * 2);
 }
 
-require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+$root_path = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+} else {
+    require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+}
+
 require_once dirname(__FILE__) . '/../lib/dfCms_build.php';
 
 if (!defined('_PS_VERSION_')) {

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -30,8 +30,16 @@ if (function_exists('set_time_limit')) {
     @set_time_limit(3600 * 2);
 }
 
-require_once dirname(__FILE__) . '/../../../config/config.inc.php';
-require_once dirname(__FILE__) . '/../../../init.php';
+$root_path = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+    require_once $root_path . '/init.php';
+} else {
+    require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+    require_once dirname(__FILE__) . '/../../../init.php';
+}
+
 require_once dirname(__FILE__) . '/../doofinder.php';
 
 dfTools::validateSecurityToken(Tools::getValue('dfsec_hash'));

--- a/landing.php
+++ b/landing.php
@@ -12,7 +12,13 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
-require_once dirname(__FILE__) . '/../../config/config.inc.php';
+$root_path = dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME'])));
+$config_file_path = $root_path . '/config/config.inc.php';
+if (file_exists($config_file_path)) {
+    require_once $config_file_path;
+} else {
+    require_once dirname(__FILE__) . '/../../config/config.inc.php';
+}
 
 if (!defined('_PS_VERSION_')) {
     exit;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2312

Until now, we were applying relative path traversing with `../../` to get the `config.inc.php` and other files in several parts of the code which should be fine in most of the cases, but we have found out a customer who has the modules under a symbolic link which breaks the logic of ../../. Instead of this one, we have used a different approach with `$_SERVER['SCRIPT_FILENAME']` and `dirname()`, leaving the previous way as a fallback.

![image](https://github.com/doofinder/doofinder-prestashop/assets/128705267/560e7d46-e971-44ae-84c5-ae1269a28303)

(In this example modules is a symlink pointing to `/.ftp-users/modules`)