### PR TITLE
PLUGINRANGERS-2200 | Removed nonexistent SQL field in PS 1.6 or lower

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.29';
+    const VERSION = '4.7.30';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.29';
+        $this->version = '4.7.30';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
@@ -1824,7 +1824,8 @@ class Doofinder extends Module
 
         if ($result) {
             $key = str_replace('DF_HASHID_', '', $result);
-            $iso_code = explode('_', $key)[1];
+            $iso_code_parts = explode('_', $key);
+            $iso_code = end($iso_code_parts);
 
             return (int) $this->getLanguageIdByLocale($iso_code);
         } else {
@@ -1846,8 +1847,7 @@ class Doofinder extends Module
         return Db::getInstance()
             ->getValue(
                 'SELECT `id_lang` FROM `' . _DB_PREFIX_ . 'lang`
-                WHERE `locale` = \'' . $sanitized_locale . '\'
-                OR `language_code` = \'' . $sanitized_locale . '\'
+                WHERE `language_code` = \'' . $sanitized_locale . '\'
                 OR `iso_code` = \'' . $sanitized_locale . '\''
             );
     }


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2200

The field `locale` does not exist in the `ps_lang` table in PS 1.6

![image](https://github.com/doofinder/doofinder-prestashop/assets/128705267/fff29872-565c-4662-b9d0-f43d29d1cdcf)
