### PR TITLE
PLUGINRANGERS-2312 | Fixed all ../ paths for symlinks + replaced by relative paths where possible

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -13,7 +13,7 @@
  * @license   GPLv3
  */
 if (!class_exists('dfTools')) {
-    require_once dirname(__FILE__) . '/lib/dfTools.class.php';
+    require_once 'lib/dfTools.class.php';
 }
 
 if (!defined('_PS_VERSION_')) {
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.30';
+    const VERSION = '4.7.31';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.30';
+        $this->version = '4.7.31';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
@@ -825,6 +825,10 @@ class Doofinder extends Module
         if (empty($df_querySelector)) {
             $df_querySelector = '#search_query_top';
         }
+        $self_path = dirname($_SERVER['SCRIPT_FILENAME']);
+        if (!is_dir($self_path)) {
+            $self_path = dirname(__FILE__);
+        }
         $this->smarty->assign([
             'ENT_QUOTES' => ENT_QUOTES,
             'lang' => Tools::strtolower($lang),
@@ -833,7 +837,7 @@ class Doofinder extends Module
             'productLinks' => $this->productLinks,
             'search_engine_id' => $search_engine_id,
             'df_region' => $df_region,
-            'self' => dirname(__FILE__),
+            'self' => $self_path,
             'df_another_params' => $params,
             'installation_ID' => $installation_ID,
             'currency' => $currency,
@@ -890,7 +894,11 @@ class Doofinder extends Module
         $cssVS = (int) Configuration::get('DF_CSS_VS');
         $file = 'doofinder_custom_' . $this->context->shop->id . '_vs_' . $cssVS . '.css';
         if ($extraCSS) {
-            if (file_exists(dirname(__FILE__) . '/views/css/' . $file)) {
+            $file_path = dirname($_SERVER['SCRIPT_FILENAME']) . '/views/css/' . $file;
+            if (!file_exists($file_path)) {
+                $file_path = dirname(__FILE__) . '/views/css/' . $file;
+            }
+            if (file_exists($file_path)) {
                 $this->context->controller->addCSS(
                     $this->_path . 'views/css/' . $file,
                     'all'
@@ -1137,7 +1145,7 @@ class Doofinder extends Module
 
         if ($hashid) {
             if ($action == 'update') {
-                require_once dirname(__FILE__) . '/lib/dfProduct_build.php';
+                require_once 'lib/dfProduct_build.php';
                 $builder = new DfProductBuild($id_shop, $id_lang, $id_currency);
                 $builder->setProducts($products);
                 $payload = $builder->build();
@@ -1170,7 +1178,7 @@ class Doofinder extends Module
 
         if ($hashid) {
             if ($action == 'update') {
-                require_once dirname(__FILE__) . '/lib/dfCms_build.php';
+                require_once 'lib/dfCms_build.php';
 
                 $builder = new DfCmsBuild($id_shop, $id_lang);
                 $builder->setCmsPages($cms_pages);
@@ -1204,7 +1212,7 @@ class Doofinder extends Module
 
         if ($hashid) {
             if ($action == 'update') {
-                require_once dirname(__FILE__) . '/lib/dfCategory_build.php';
+                require_once 'lib/dfCategory_build.php';
 
                 $builder = new DfCategoryBuild($id_shop, $id_lang);
                 $builder->setCategories($categories);
@@ -1223,7 +1231,7 @@ class Doofinder extends Module
             return;
         }
 
-        require_once dirname(__FILE__) . '/lib/doofinder_api_items.php';
+        require_once 'lib/doofinder_api_items.php';
 
         $apikey = explode('-', Configuration::get('DF_API_KEY'))[1];
         $region = Configuration::get('DF_REGION');
@@ -1242,7 +1250,7 @@ class Doofinder extends Module
             return;
         }
 
-        require_once dirname(__FILE__) . '/lib/doofinder_api_items.php';
+        require_once 'lib/doofinder_api_items.php';
 
         $apikey = explode('-', Configuration::get('DF_API_KEY'))[1];
         $region = Configuration::get('DF_REGION');
@@ -1257,7 +1265,7 @@ class Doofinder extends Module
 
     private function indexApiInvokeReindexing()
     {
-        require_once dirname(__FILE__) . '/lib/doofinder_api_index.php';
+        require_once 'lib/doofinder_api_index.php';
 
         $region = Configuration::get('DF_REGION');
         $api_key = Configuration::get('DF_API_KEY');
@@ -1282,7 +1290,7 @@ class Doofinder extends Module
     public function testDoofinderApi($onlyOneLang = false)
     {
         if (!class_exists('DoofinderApi')) {
-            include_once dirname(__FILE__) . '/lib/doofinder_api.php';
+            include_once 'lib/doofinder_api.php';
         }
         $result = false;
         $messages = '';
@@ -1373,7 +1381,7 @@ class Doofinder extends Module
             $fail = false;
             try {
                 if (!class_exists('DoofinderApi')) {
-                    include_once dirname(__FILE__) . '/lib/doofinder_api.php';
+                    include_once 'lib/doofinder_api.php';
                 }
                 $df = new DoofinderApi($hash_id, $api_key, false, ['apiVersion' => '5']);
                 $queryParams = [
@@ -1943,9 +1951,12 @@ class Doofinder extends Module
 
     private function debug($message)
     {
-        $debug = Configuration::get('DF_DEBUG', null);
+        $current_path = dirname($_SERVER['SCRIPT_FILENAME']);
+        if (!is_dir($current_path)) {
+            $current_path = dirname(__FILE__);
+        }
         if (isset($debug) && $debug) {
-            error_log("$message\n", 3, dirname(__FILE__) . '/doofinder.log');
+            error_log("$message\n", 3, $current_path . '/doofinder.log');
         }
     }
 

--- a/feed.php
+++ b/feed.php
@@ -26,15 +26,15 @@ if (!defined('_PS_VERSION_')) {
 
 switch (Tools::getValue('type')) {
     case 'category':
-        require dirname(__FILE__) . '/feeds/category.php';
+        require 'feeds/category.php';
         break;
 
     case 'page':
-        require dirname(__FILE__) . '/feeds/cms.php';
+        require 'feeds/cms.php';
         break;
 
     case 'product':
     default:
-        require dirname(__FILE__) . '/feeds/product.php';
+        require 'feeds/product.php';
         break;
 }

--- a/feeds/category.php
+++ b/feeds/category.php
@@ -20,11 +20,11 @@ $root_path = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
 $config_file_path = $root_path . '/config/config.inc.php';
 if (file_exists($config_file_path)) {
     require_once $config_file_path;
+    require_once dirname(dirname($_SERVER['SCRIPT_FILENAME'])) . '/lib/dfCategory_build.php';
 } else {
     require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+    require_once dirname(__FILE__) . '/../lib/dfCategory_build.php';
 }
-
-require_once dirname(__FILE__) . '/../lib/dfCategory_build.php';
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/feeds/cms.php
+++ b/feeds/cms.php
@@ -20,11 +20,11 @@ $root_path = dirname(dirname(dirname(dirname($_SERVER['SCRIPT_FILENAME']))));
 $config_file_path = $root_path . '/config/config.inc.php';
 if (file_exists($config_file_path)) {
     require_once $config_file_path;
+    require_once dirname(dirname($_SERVER['SCRIPT_FILENAME'])) . '/lib/dfCategory_build.php';
 } else {
     require_once dirname(__FILE__) . '/../../../config/config.inc.php';
+    require_once dirname(__FILE__) . '/../lib/dfCms_build.php';
 }
-
-require_once dirname(__FILE__) . '/../lib/dfCms_build.php';
 
 if (!defined('_PS_VERSION_')) {
     exit;

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -35,12 +35,12 @@ $config_file_path = $root_path . '/config/config.inc.php';
 if (file_exists($config_file_path)) {
     require_once $config_file_path;
     require_once $root_path . '/init.php';
+    require_once dirname(dirname($_SERVER['SCRIPT_FILENAME'])) . '/doofinder.php';
 } else {
     require_once dirname(__FILE__) . '/../../../config/config.inc.php';
     require_once dirname(__FILE__) . '/../../../init.php';
+    require_once dirname(__FILE__) . '/../doofinder.php';
 }
-
-require_once dirname(__FILE__) . '/../doofinder.php';
 
 dfTools::validateSecurityToken(Tools::getValue('dfsec_hash'));
 
@@ -169,7 +169,7 @@ if ($debug) {
 }
 
 if ($cfg_debug) {
-    error_log("Starting feed.\n", 3, dirname(__FILE__) . '/doofinder.log');
+    error_log("Starting feed.\n", 3, 'doofinder.log');
 }
 
 // OUTPUT

--- a/lib/dfCategory_build.php
+++ b/lib/dfCategory_build.php
@@ -13,7 +13,7 @@
  * @license   GPLv3
  */
 if (!class_exists('dfTools')) {
-    require_once dirname(__FILE__) . '/dfTools.class.php';
+    require_once 'dfTools.class.php';
 }
 
 if (!defined('_PS_VERSION_')) {

--- a/lib/dfCms_build.php
+++ b/lib/dfCms_build.php
@@ -13,7 +13,7 @@
  * @license   GPLv3
  */
 if (!class_exists('dfTools')) {
-    require_once dirname(__FILE__) . '/dfTools.class.php';
+    require_once 'dfTools.class.php';
 }
 
 if (!defined('_PS_VERSION_')) {

--- a/lib/dfProduct_build.php
+++ b/lib/dfProduct_build.php
@@ -17,7 +17,7 @@ if (!defined('_PS_VERSION_')) {
 }
 
 if (!class_exists('dfTools')) {
-    require_once dirname(__FILE__) . '/lib/dfTools.class.php';
+    require_once 'lib/dfTools.class.php';
 }
 
 class DfProductBuild

--- a/lib/doofinder_api.php
+++ b/lib/doofinder_api.php
@@ -614,5 +614,5 @@ class DoofinderApi
     }
 }
 
-include_once dirname(__FILE__) . '/DoofinderResults.php';
-include_once dirname(__FILE__) . '/DoofinderException.php';
+include_once 'DoofinderResults.php';
+include_once 'DoofinderException.php';


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2312

If a customer has the module folder as a symlink (like this one described in the support issue) the ../ paths or some absolute paths do not work as expected using `dirname(__FILE__)` or `__DIR__`. This PR solves this situation. This is an edge-case. If a relative path can be used, it will be used instead of its absolute version.