### PR TITLE
fix: Assign lowest variant price to parent

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -32,7 +32,7 @@ class Doofinder extends Module
     const DOOMANAGER_URL = 'https://admin.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.7.33';
+    const VERSION = '4.7.34';
     const YES = 1;
     const NO = 0;
 
@@ -40,7 +40,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.7.33';
+        $this->version = '4.7.34';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1395,8 +1395,8 @@ class DfTools
 
                 /*
                 Even though, in order to track the minimum, we can only focus on
-                the sales price, we still need both prices of the variant
-                in order to properly and consistenly populate the price of
+                the sale price, we still need both prices of the variant
+                in order to properly and consistently populate the price of
                 the parent to show the proper price vs sale_price when searching
                 in the layer
                 */

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1393,11 +1393,13 @@ class DfTools
             if (key_exists($product_id, $min_prices_by_product_id)) {
                 $current_min_prices = $min_prices_by_product_id[$product_id];
 
-                // Even though, in order to track the minimum, we can only focus on
-                // the sales price, we still need both prices of the variant
-                // in order to properly and consistenly populate the price of
-                // the parent to show the proper price vs sale_price when searching
-                // in the layer
+                /*
+                Even though, in order to track the minimum, we can only focus on
+                the sales price, we still need both prices of the variant
+                in order to properly and consistenly populate the price of
+                the parent to show the proper price vs sale_price when searching
+                in the layer
+                */
                 if ($variant_onsale_price < $current_min_prices['onsale_price']) {
                     $min_prices_by_product_id[$product_id]['price'] = $variant_price;
                     $min_prices_by_product_id[$product_id]['onsale_price'] = $variant_onsale_price;
@@ -1412,7 +1414,7 @@ class DfTools
 
     public static function is_parent($product)
     {
-        return isset($product['id_product_attribute']) && (int) $product['id_product_attribute'] === 0;
+        return isset($product['id_product_attribute']) && is_numeric($product['id_product_attribute']) && (int) $product['id_product_attribute'] === 0;
     }
 
     public static function get_price($product_id, $include_taxes, $variant_id = null)

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1376,4 +1376,65 @@ class DfTools
     {
         return is_null($subject) ? null : preg_replace($pattern, $replacement, $subject);
     }
+
+    public static function get_min_variant_prices($products, $include_taxes)
+    {
+        $min_prices_by_product_id = [];
+        foreach ($products as $product) {
+            if (self::is_parent($product)) {
+                continue;
+            }
+
+            $product_id = $product['id_product'];
+            $variant_id = $product['id_product_attribute'];
+            $variant_price = self::get_price($product_id, $include_taxes, $variant_id);
+            $variant_onsale_price = self::get_onsale_price($product_id, $include_taxes, $variant_id);
+
+            if (key_exists($product_id, $min_prices_by_product_id)) {
+                $current_min_prices = $min_prices_by_product_id[$product_id];
+
+                // Even though, in order to track the minimum, we can only focus on
+                // the sales price, we still need both prices of the variant
+                // in order to properly and consistenly populate the price of
+                // the parent to show the proper price vs sale_price when searching
+                // in the layer
+                if ($variant_onsale_price < $current_min_prices['onsale_price']) {
+                    $min_prices_by_product_id[$product_id]['price'] = $variant_price;
+                    $min_prices_by_product_id[$product_id]['onsale_price'] = $variant_onsale_price;
+                }
+            } else {
+                $min_prices_by_product_id[$product_id] = ['price' => $variant_price, 'onsale_price' => $variant_onsale_price];
+            }
+        }
+
+        return $min_prices_by_product_id;
+    }
+
+    public static function is_parent($product)
+    {
+        return isset($product['id_product_attribute']) && (int) $product['id_product_attribute'] === 0;
+    }
+
+    public static function get_price($product_id, $include_taxes, $variant_id = null)
+    {
+        return Product::getPriceStatic(
+            $product_id,
+            $include_taxes,
+            $variant_id,
+            6,
+            null,
+            false,
+            false
+        );
+    }
+
+    public static function get_onsale_price($product_id, $include_taxes, $variant_id = null)
+    {
+        return Product::getPriceStatic(
+            $product_id,
+            $include_taxes,
+            $variant_id,
+            6
+        );
+    }
 }


### PR DESCRIPTION
Required by #198.

In case a product has variants and one of the variants has a lower price than the parent's assigned price, the price to be indexed needs to be the lowest price of the variants. This allows the lowest price of the variants to be the one displayed when searching for the product in the layer.