### PR TITLE
First draft changes to adapt the plugin

### DIFF
--- a/config.php
+++ b/config.php
@@ -62,6 +62,7 @@ $prices_with_taxes = (bool) Configuration::get('DF_GS_PRICES_USE_TAX');
 
 foreach (Language::getLanguages(true, $context->shop->id) as $lang) {
     $lang = Tools::strtoupper($lang['iso_code']);
+    //TODO: Is this still needed?
     $currency = dfTools::getCurrencyForLanguage($lang);
 
     $languages[] = $lang;

--- a/controllers/front/landing.php
+++ b/controllers/front/landing.php
@@ -42,7 +42,7 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
 
         $landing_name = Tools::getValue('landing_name');
 
-        $this->landing_data = $this->getLandingData($landing_name, $this->context->shop->id, $this->context->language->id, $this->context->currency->id);
+        $this->landing_data = $this->getLandingData($landing_name, $this->context->shop->id, $this->context->language->id);
 
         if (!$this->landing_data) {
             Tools::redirect('index.php?controller=404');
@@ -149,9 +149,9 @@ class DoofinderLandingModuleFrontController extends ModuleFrontController
         return $page;
     }
 
-    private function getLandingData($name, $id_shop, $id_lang, $id_currency)
+    private function getLandingData($name, $id_shop, $id_lang)
     {
-        $hashid = $this->module->getHashId($id_lang, $id_currency);
+        $hashid = $this->module->getHashId($id_lang);
         $cache = $this->getLandingCache($name, $hashid);
 
         if ($cache && !$this->refreshCache($cache)) {

--- a/lib/dfTools.class.php
+++ b/lib/dfTools.class.php
@@ -1171,6 +1171,7 @@ class DfTools
      *
      * @return Currency
      */
+    //TODO: Is this still used?
     public static function getCurrencyForLanguage($code)
     {
         $optname = 'DF_GS_CURRENCY_' . strtoupper($code);
@@ -1256,6 +1257,7 @@ class DfTools
      *
      * @return string URL
      */
+    //TODO: Is this still needed?
     public static function getFeedURL($langIsoCode)
     {
         $currency = self::getCurrencyForLanguage($langIsoCode);

--- a/lib/doofinder_layer_api.php
+++ b/lib/doofinder_layer_api.php
@@ -25,6 +25,7 @@ class DoofinderLayerApi
      * Since this API returns the default hashid if both currency and language do not match,
      * a check is made to see if the desired hashid is returned.
      */
+    //TODO: Is this needed?
     public static function getHashidByInstallationID($installationID, $currency, $language)
     {
         $client = new EasyREST();

--- a/views/templates/admin/feed_url_partial_tab.tpl
+++ b/views/templates/admin/feed_url_partial_tab.tpl
@@ -19,7 +19,7 @@
 				<h4>{l s='Feed URLs to use on Doofinder Admin panel' mod='doofinder'}</h4>
 				<dl>
 					{foreach from=$df_feed_urls item=feed_url}
-						<dt>{l s='Data feed URL for ' mod='doofinder'} [{$feed_url.lang|escape:'htmlall':'UTF-8'} - {$feed_url.currency|escape:'htmlall':'UTF-8'}]<dt>
+						<dt>{l s='Data feed URL for ' mod='doofinder'} [{$feed_url.lang|escape:'htmlall':'UTF-8'}]<dt>
 						<dd><a href="{html_entity_decode($feed_url.url|escape:'htmlall':'UTF-8')}" target="_blank">{$feed_url.url|escape:'htmlall':'UTF-8'}</a></dd>
 					{/foreach}
 				</dl>

--- a/views/templates/front/scriptV9.tpl
+++ b/views/templates/front/scriptV9.tpl
@@ -48,6 +48,8 @@
     {/literal}
 
     // Custom personalization:
+
+    //TODO: Adapt in case the layer needs a different format
     doofinderApp("config", "language", "{$lang|escape:'htmlall':'UTF-8'}");
     doofinderApp("config", "currency", "{$currency|escape:'htmlall':'UTF-8'}");
   </script>


### PR DESCRIPTION
Changes required by the prestashop plugin to adapt to multiprice search engines.

### Decisions

- I've decided to keep the language as we did for the feed URLs but remove the currency.
- We are not saving the currencies for the search engine anywhere as we use all currencies for all languages. Because we can obtain the list of currencies at any moment, this allows us to dynamically populate prices without keeping track of currencies anywhere.
- We were saving the search engine Hash IDs per language-currency. We could keep this but it doesn't go well with the previous decision of dynamically obtaining the currencies at indexation time. Hence, I've also changed the format of the hash ID configs.

### Open Items / Questions

- How are we going to handle the retrocompatibility/deployment?
- Is there any update needed in the script?
- Is there any update needed due to changes in the Installation search engine mapping?
- How are we going to determine which currency symbol to use? Does it have any impact on the plugin?
- Is there any update on the response to the Doomanager create store request? How does the SE field change?

