### PR TITLE
PLUGINRANGERS-2877 | Removed use statements from main module file

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -18,11 +18,12 @@ if (!defined('_PS_VERSION_')) {
 
 require_once 'autoloader.php';
 
-use PrestaShop\Module\Doofinder\Src\Entity\DoofinderAdminPanelView;
-use PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation;
-use PrestaShop\Module\Doofinder\Src\Entity\DoofinderScript;
-use PrestaShop\Module\Doofinder\Src\Entity\HookManager;
-use PrestaShop\Module\Doofinder\Src\Entity\SearchEngine;
+/*
+We cannot use the `use` statement in the main module file due to a eval function
+included in PrestaShop 1.6.X or lower. That's why several classes are defined with
+the namespace prepended directly:
+https://github.com/gskema/prestashop-1.6-module-boilerplate/blob/master/docs/namespaces.md#how-to-use-php-namespaces-in-prestashop-modules
+*/
 
 class Doofinder extends Module
 {
@@ -38,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.9.1';
+        $this->version = '4.9.2';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
@@ -50,7 +51,7 @@ class Doofinder extends Module
 
         $this->confirmUninstall = $this->l('Are you sure? This will not cancel your account in Doofinder service');
         $this->admin_template_dir = '../../../../modules/' . $this->name . '/views/templates/admin/';
-        $this->hookManager = new HookManager($this);
+        $this->hookManager = new PrestaShop\Module\Doofinder\Src\Entity\HookManager($this);
     }
 
     /**
@@ -61,8 +62,8 @@ class Doofinder extends Module
     public function install()
     {
         return parent::install()
-            && DoofinderInstallation::installDb()
-            && DoofinderInstallation::installTabs()
+            && PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation::installDb()
+            && PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation::installTabs()
             && $this->hookManager->registerHooks();
     }
 
@@ -74,9 +75,9 @@ class Doofinder extends Module
     public function uninstall()
     {
         return parent::uninstall()
-            && DoofinderInstallation::uninstallTabs()
-            && DoofinderInstallation::deleteConfigVars()
-            && DoofinderInstallation::uninstallDb();
+            && PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation::uninstallTabs()
+            && PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation::deleteConfigVars()
+            && PrestaShop\Module\Doofinder\Src\Entity\DoofinderInstallation::uninstallDb();
     }
 
     /**
@@ -121,7 +122,7 @@ class Doofinder extends Module
      */
     public function hookModuleRoutes()
     {
-        return HookManager::getHookModuleRoutes();
+        return PrestaShop\Module\Doofinder\Src\Entity\HookManager::getHookModuleRoutes();
     }
 
     /**
@@ -132,7 +133,7 @@ class Doofinder extends Module
      */
     public function setSearchEnginesByConfig()
     {
-        return SearchEngine::setSearchEnginesByConfig();
+        return PrestaShop\Module\Doofinder\Src\Entity\SearchEngine::setSearchEnginesByConfig();
     }
 
     /**
@@ -142,7 +143,7 @@ class Doofinder extends Module
      */
     public function getContent()
     {
-        $adminPanelView = new DoofinderAdminPanelView($this);
+        $adminPanelView = new PrestaShop\Module\Doofinder\Src\Entity\DoofinderAdminPanelView($this);
 
         return $adminPanelView->getContent();
     }
@@ -182,7 +183,7 @@ class Doofinder extends Module
      */
     public function hookDisplayHeader($params)
     {
-        if (!DoofinderScript::searchLayerMustBeInitialized()) {
+        if (!PrestaShop\Module\Doofinder\Src\Entity\DoofinderScript::searchLayerMustBeInitialized()) {
             return '';
         }
 
@@ -198,7 +199,7 @@ class Doofinder extends Module
      */
     public function displaySingleScript()
     {
-        $this->context->controller->addJS(DoofinderScript::getSingleScriptPath($this->_path));
+        $this->context->controller->addJS(PrestaShop\Module\Doofinder\Src\Entity\DoofinderScript::getSingleScriptPath($this->_path));
 
         return $this->display(__FILE__, 'views/templates/front/scriptV9.tpl');
     }
@@ -209,7 +210,7 @@ class Doofinder extends Module
     public function hookActionProductSave($params)
     {
         $action = $params['product']->active ? 'update' : 'delete';
-        HookManager::proccessHookUpdateOnSave('product', $params['id_product'], $this->context->shop->id, $action);
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('product', $params['id_product'], $this->context->shop->id, $action);
     }
 
     /**
@@ -217,7 +218,7 @@ class Doofinder extends Module
      */
     public function hookActionProductDelete($params)
     {
-        HookManager::proccessHookUpdateOnSave('product', $params['id_product'], $this->context->shop->id, 'delete');
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('product', $params['id_product'], $this->context->shop->id, 'delete');
     }
 
     /**
@@ -226,7 +227,7 @@ class Doofinder extends Module
     public function hookActionObjectCmsAddAfter($params)
     {
         if ($params['object']->active) {
-            HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, 'update');
+            PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, 'update');
         }
     }
 
@@ -236,7 +237,7 @@ class Doofinder extends Module
     public function hookActionObjectCmsUpdateAfter($params)
     {
         $action = $params['object']->active ? 'update' : 'delete';
-        HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, $action);
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, $action);
     }
 
     /**
@@ -244,7 +245,7 @@ class Doofinder extends Module
      */
     public function hookActionObjectCmsDeleteAfter($params)
     {
-        HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, 'delete');
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('cms', $params['object']->id, $this->context->shop->id, 'delete');
     }
 
     /**
@@ -253,7 +254,7 @@ class Doofinder extends Module
     public function hookActionObjectCategoryAddAfter($params)
     {
         if ($params['object']->active) {
-            HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, 'update');
+            PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, 'update');
         }
     }
 
@@ -263,7 +264,7 @@ class Doofinder extends Module
     public function hookActionObjectCategoryUpdateAfter($params)
     {
         $action = $params['object']->active ? 'update' : 'delete';
-        HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, $action);
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, $action);
     }
 
     /**
@@ -271,7 +272,7 @@ class Doofinder extends Module
      */
     public function hookActionObjectCategoryDeleteAfter($params)
     {
-        HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, 'delete');
+        PrestaShop\Module\Doofinder\Src\Entity\HookManager::proccessHookUpdateOnSave('category', $params['object']->id, $this->context->shop->id, 'delete');
     }
 
     /**
@@ -284,7 +285,7 @@ class Doofinder extends Module
     private function configureHookCommon($params = false)
     {
         $this->smarty->assign(
-            HookManager::getHookCommonSmartyAssigns(
+            PrestaShop\Module\Doofinder\Src\Entity\HookManager::getHookCommonSmartyAssigns(
                 $this->context->language->language_code,
                 $this->context->currency->iso_code,
                 $this->productLinks,

--- a/src/Entity/DfCategoryBuild.php
+++ b/src/Entity/DfCategoryBuild.php
@@ -66,6 +66,9 @@ class DfCategoryBuild
 
         $c = [];
 
+        $tableName = 'category';
+        $tableName = (method_exists('ImageType', 'getFormattedName')) ? \ImageType::getFormattedName($tableName) : $tableName . '_default';
+
         $c['id'] = (string) $category->id;
         $c['title'] = DfTools::cleanString($category->name);
         $c['description'] = DfTools::cleanString($category->description);
@@ -73,7 +76,7 @@ class DfCategoryBuild
         $c['meta_description'] = DfTools::cleanString($category->meta_description);
         $c['tags'] = DfTools::cleanString($category->meta_keywords);
         $c['link'] = $this->link->getCategoryLink($category);
-        $c['image_link'] = $category->id_image ? $this->link->getCatImageLink($category->link_rewrite, $category->id_image, \ImageType::getFormattedName('category')) : '';
+        $c['image_link'] = $category->id_image ? $this->link->getCatImageLink($category->link_rewrite, $category->id_image, $tableName) : '';
 
         return $c;
     }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -82,6 +82,8 @@ class DfTools
     public static function getAvailableImageSizes()
     {
         $sizes = [];
+        $tableName = 'home';
+        $tableName = (method_exists(\ImageType::class, 'getFormattedName')) ? \ImageType::getFormattedName($tableName) : $tableName . '_default';
         $sql = "
         SELECT
             `name` AS DF_GS_IMAGE_SIZE,
@@ -92,7 +94,7 @@ class DfTools
             `products` = 1
         ORDER BY
             CASE
-                WHEN name = '" . \ImageType::getFormattedName('home') . "' THEN '1'
+                WHEN name = '" . $tableName . "' THEN '1'
             END DESC;
         ";
 

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.9.1';
+    const VERSION = '4.9.2';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/2877

We cannot use the `use` statement in the main module file due to a eval function
included in PrestaShop 1.6.X or lower. That's why several classes are defined with
the namespace prepended directly:
https://github.com/gskema/prestashop-1.6-module-boilerplate/blob/master/docs/namespaces.md#how-to-use-php-namespaces-in-prestashop-modules