### PR TITLE
Hashid error in form

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.9.3';
+        $this->version = '4.9.4';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -102,13 +102,17 @@ class DoofinderApi
             }
         }
         $patt = '/^[0-9a-f]{32}$/i';
-        if (!preg_match($patt, $hashid)) {
+
+        if ($hashid != false && !preg_match($patt, $hashid)) {
             throw new DoofinderException('Wrong hashid');
+        } else {
+            $this->hashid = $hashid;
         }
+
         if (!in_array($this->apiVersion, ['5', '4', '3.0', '1.0'])) {
             throw new DoofinderException('Wrong API');
         }
-        $this->hashid = $hashid;
+
         if ($fromParams) {
             $this->fromQuerystring();
         }

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.9.3';
+    const VERSION = '4.9.4';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4';
+    const VERSION = '4.9.3';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.9.3';
+    const VERSION = '4';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/2930

With this change we do not launch a fatal error and simply indicate it in the messages. The client would have to add the values manually to the database.

![image](https://github.com/user-attachments/assets/7d2ebb11-110c-44bc-9f9b-394ed1be95d6)
