### PR TITLE
Skip feed url update for stores without installation ID

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.12.2';
+        $this->version = '4.12.3';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.12.2';
+    const VERSION = '4.12.3';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderInstallation.php
+++ b/src/Entity/DoofinderInstallation.php
@@ -221,11 +221,17 @@ class DoofinderInstallation
 
         DoofinderConfig::debug('Update Feed urls for the following SHOPS:');
         DoofinderConfig::debug(print_r($shops, true));
+        $apiKey = DfTools::getFormattedApiKey();
+        
+        if (empty($apiKey)) {
+            $errorMsg = 'Unable to update feed urls: Missing API KEY';
+            DoofinderConfig::debug($errorMsg);
+            throw new \Exception($errorMsg);
+        }
 
         foreach ($shops as $shop) {
             $feed_urls = [];
             $client = new EasyREST();
-            $apiKey = DfTools::getFormattedApiKey();
             $languages = \Language::getLanguages(true, $shop['id_shop']);
             $currencies = \Currency::getCurrenciesByIdShop($shop['id_shop']);
             $shopId = $shop['id_shop'];

--- a/src/Entity/DoofinderInstallation.php
+++ b/src/Entity/DoofinderInstallation.php
@@ -222,7 +222,7 @@ class DoofinderInstallation
         DoofinderConfig::debug('Update Feed urls for the following SHOPS:');
         DoofinderConfig::debug(print_r($shops, true));
         $apiKey = DfTools::getFormattedApiKey();
-        
+
         if (empty($apiKey)) {
             $errorMsg = 'Unable to update feed urls: Missing API KEY';
             DoofinderConfig::debug($errorMsg);

--- a/src/Entity/DoofinderInstallation.php
+++ b/src/Entity/DoofinderInstallation.php
@@ -219,6 +219,9 @@ class DoofinderInstallation
     {
         $shops = \Shop::getShops();
 
+        DoofinderConfig::debug('Update Feed urls for the following SHOPS:');
+        DoofinderConfig::debug(print_r($shops, true));
+
         foreach ($shops as $shop) {
             $feed_urls = [];
             $client = new EasyREST();

--- a/src/Entity/DoofinderInstallation.php
+++ b/src/Entity/DoofinderInstallation.php
@@ -219,9 +219,6 @@ class DoofinderInstallation
     {
         $shops = \Shop::getShops();
 
-        DoofinderConfig::debug('SHOPS:');
-        DoofinderConfig::debug(print_r($shops, true));
-
         foreach ($shops as $shop) {
             $feed_urls = [];
             $client = new EasyREST();
@@ -231,6 +228,11 @@ class DoofinderInstallation
             $shopId = $shop['id_shop'];
             $shopGroupId = $shop['id_shop_group'];
             $installationID = \Configuration::get('DF_INSTALLATION_ID', null, $shopGroupId, $shopId);
+
+            if (empty($installationID)) {
+                continue;
+            }
+
             DoofinderConfig::debug("Updating feed urls for shop: {$shopId} and group: {$shopGroupId}");
 
             foreach ($languages as $lang) {

--- a/upgrade/upgrade-4.12.0.php
+++ b/upgrade/upgrade-4.12.0.php
@@ -35,8 +35,16 @@ function upgrade_module_4_12_0($module)
 {
     DoofinderConfig::debug('Initiating 4.12.0 upgrade');
 
-    // Update feed URLs
+    // Update feed URLs    
     DoofinderInstallation::updateFeedUrls();
+
+    try {
+        DoofinderInstallation::updateFeedUrls();
+    } catch (Exception $exception) {
+        PrestaShopLogger::addLog($exception->getMessage(), 3, $exception->getCode(), 'Module', $module->id);
+        return false;
+    }
+
     DoofinderConfig::debug('Feed URLs updated successfully.');
 
     // Delete old *.php files

--- a/upgrade/upgrade-4.12.0.php
+++ b/upgrade/upgrade-4.12.0.php
@@ -35,7 +35,7 @@ function upgrade_module_4_12_0($module)
 {
     DoofinderConfig::debug('Initiating 4.12.0 upgrade');
 
-    // Update feed URLs    
+    // Update feed URLs
     DoofinderInstallation::updateFeedUrls();
 
     try {


### PR DESCRIPTION
Al actualizar las urls de los feeds no se está teniendo en cuenta si la store que se está procesando existe en doofinder, por lo que se produce un error evitando que se finalice la actualización correctamente.

Se ha añadido una comprobación para que en caso de que la store de PrestaShop no esté creada en nuestros sistemas, se ignore la actualización de las urls de los feeds permitiendo que se finalice correctamente la actualización del módulo.

