### PR TITLE
PLUGINRANGERS-3261 | Added compatibility for ajaxRender

### DIFF
--- a/controllers/front/ajax.php
+++ b/controllers/front/ajax.php
@@ -44,14 +44,32 @@ class DoofinderAjaxModuleFrontController extends ModuleFrontController
             if (Tools::getValue('token') == DfTools::encrypt('doofinder-ajax')) {
                 header('Content-Type:application/json; charset=utf-8');
                 DoofinderInstallation::autoinstaller($shopId);
-                $this->ajaxRender(json_encode(['success' => true]));
-                exit;
+                $this->compatRender(json_encode(['success' => true]));
             } else {
-                $this->ajaxRender(json_encode([
+                $this->compatRender(json_encode([
                     'success' => false, 'errors' => ['Forbidden access. Invalid token for autoinstaller.'],
                 ]));
-                exit;
             }
         }
+    }
+
+    /**
+     * The native function exists only after PrestaShop 1.7, so in order
+     * to keep compatibility with PrestaShop 1.6 we must keep `ajaxDie` as a fallback.
+     *
+     * @param string|null $value
+     * @param string|null $controller
+     * @param string|null $method
+     *
+     * @throws PrestaShopException
+     */
+    private function compatRender($value = null, $controller = null, $method = null)
+    {
+        if (method_exists($this, 'ajaxRender')) {
+            $this->ajaxRender($value, $controller, $method);
+            exit;
+        }
+
+        $this->ajaxDie($value, $controller, $method);
     }
 }

--- a/controllers/front/config.php
+++ b/controllers/front/config.php
@@ -98,12 +98,13 @@ class DoofinderConfigModuleFrontController extends ModuleFrontController
             ],
         ];
 
+        $jsonCfg = DfTools::jsonEncode($cfg);
         if (method_exists($this, 'ajaxRender')) {
-            $this->ajaxRender(DfTools::jsonEncode($cfg));
+            $this->ajaxRender($jsonCfg);
+            exit;
         } else {
             // Workaround for PS 1.6 as ajaxRender is not available
-            echo DfTools::jsonEncode($cfg);
-            exit;
+            $this->ajaxDie($jsonCfg);
         }
     }
 }

--- a/controllers/front/feed.php
+++ b/controllers/front/feed.php
@@ -49,8 +49,13 @@ class DoofinderFeedModuleFrontController extends ModuleFrontController
         }
         $feed = ob_get_clean();
         header('Content-Type: text/csv; charset=utf-8');
-        $this->ajaxRender($feed);
-        exit;
+        if (method_exists($this, 'ajaxRender')) {
+            $this->ajaxRender($feed);
+            exit;
+        } else {
+            // Workaround for PS 1.6 as ajaxRender is not available
+            $this->ajaxDie($feed);
+        }
     }
 
     private static function get_plugin_dir()

--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.12.3';
+        $this->version = '4.12.4';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.12.3';
+    const VERSION = '4.12.4';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3261

Recently, there have been more support issues than usual regarding problems with Prestashop feeds. Initially, we though they were related to memory limits, but I came across that ajaxRender function is only supported after PrestaShop 1.7.0.0 (even their validator could not detect it). This PR should guarantee the compatibility again.

PS: Before having new comments about it, I have tried to isolate this logic in a function included in `DfTools`, but since `ajaxRender` is a protected function I was unable to pass `$this` as a parameter and use this function.