### PR TITLE
Fix incorrect price for group leader products

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.12.6';
+        $this->version = '4.12.7';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -277,7 +277,11 @@ $min_price_variant_by_product_id = $cfg_display_prices ? DfTools::getMinVariantP
 
 foreach ($rows as $row) {
     $product_id = $row['id_product'];
-    $variant_id = $row['id_product_attribute'];
+    if (DfTools::isParent($row)) {
+        $variant_id = null;
+    } else {
+        $variant_id = $row['id_product_attribute'];
+    }
     $product_price = DfTools::getPrice($product_id, $cfg_prices_w_taxes, $variant_id);
     $onsale_price = DfTools::getOnsalePrice($product_id, $cfg_prices_w_taxes, $variant_id);
     $multiprice = DfTools::getFormattedMultiprice($product_id, $cfg_prices_w_taxes, $currencies, $variant_id);

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.12.6';
+    const VERSION = '4.12.7';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
When calling [`\Product::getPriceStatic`(https://github.com/PrestaShop/PrestaShop/blob/06aea740014fed7ad96924a03489168aa885a1a8/classes/Product.php#L3329) must be null instead of `"0"` for parent product.

```
     * @param int|null $id_product_attribute Attribute identifier (optional).
     *                                       If set to false, do not apply the combination price impact.
     *                                       NULL does apply the default combination price impact
```

