### PR TITLE
PLUGINRANGERS-261 | Added Search Engines fields for the manual installation

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.13.0';
+        $this->version = '5.0.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.0.1';
+        $this->version = '5.0.2';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -137,7 +137,10 @@ class DfTools
                 $hashidKeys[] = [
                     'currency' => $currencyIso,
                     'language' => $langFullIso,
+                    'label' => $currencyIso . ' - ' . $langFullIso,
+                    'labelMultiprice' => $langFullIso,
                     'key' => 'DF_HASHID_' . $currencyIso . '_' . $langFullIso,
+                    'keyMultiprice' => 'DF_HASHID_' . $langFullIso,
                 ];
             }
         }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -118,6 +118,32 @@ class DfTools
         return $sizes;
     }
 
+    public static function getHashidKeys()
+    {
+        $hashidKeys = [];
+        $context = \Context::getContext();
+        $currencies = \Currency::getCurrenciesByIdShop($context->shop->id);
+        $languages = \Language::getLanguages(true, $context->shop->id);
+        foreach ($languages as $language) {
+            if (0 === (int) $language['active']) {
+                continue;
+            }
+            foreach ($currencies as $currency) {
+                if (1 === (int) $currency['deleted'] || 0 === (int) $currency['active']) {
+                    continue;
+                }
+                $currencyIso = strtoupper($currency['iso_code']);
+                $langFullIso = strtoupper($language['language_code']);
+                $hashidKeys[] = [
+                    'currency' => $currencyIso,
+                    'language' => $langFullIso,
+                    'key' => 'DF_HASHID_' . $currencyIso . '_' . $langFullIso,
+                ];
+            }
+        }
+        return $hashidKeys;
+    }
+
     /**
      * Returns an assoc. array. Keys are currency ISO codes. Values are currency
      * names.

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -514,9 +514,17 @@ class DoofinderAdminPanelView
                     'id' => 'id',
                     'name' => 'name'
                 ],
-                'readonly' => !$isAdvParamPresent && !$isManualInstallation,
+                'disabled' => !$isAdvParamPresent && !$isManualInstallation,
             ],
         ];
+
+        // This is necessary since disabled fields are not sent in the submit, thus causing errors.
+        if (!$isAdvParamPresent && !$isManualInstallation) {
+            $inputs[] = [
+                'type' => 'hidden',
+                'name' => 'DF_REGION',
+            ];
+        }
 
         if ($isAdvParamPresent) {
             if ($multipriceEnabled) {

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -510,7 +510,7 @@ class DoofinderAdminPanelView
             ],
         ];
 
-        if ($isAdvParamPresent || $isManualInstallation) {
+        if ($isAdvParamPresent) {
             if ($multipriceEnabled) {
                 $hashidKeys = self::getMultipriceKeys();
                 $keyToUse = 'keyMultiprice';

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -94,6 +94,7 @@ class DoofinderAdminPanelView
         ];
         $skipUrl = $context->link->getAdminLink('AdminModules', true);
         $separator = strpos($skipUrl, '?') === false ? '?' : '&';
+        // This URL will be used in `onboarding_tab.tpl` to skip the automatic store wizard.
         $skipUrl .= $separator . http_build_query($skipUrlParams);
 
         $redirect = $context->shop->getBaseURL(true, false) . $this->module->getPath() . 'config.php';

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -506,7 +506,7 @@ class DoofinderAdminPanelView
     {
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
         $isManualInstallation = (bool) \Tools::getValue('skip', 0);
-        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
+        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
         $inputs = [
             [
                 'type' => 'text',

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -45,6 +45,14 @@ class DoofinderAdminPanelView
     /**
      * Handles the module's configuration page
      *
+     * the `&first_time=1` parameter has been introduced for these purposes:
+     * - It is displayed only once and is automatically removed upon form submission or
+     *   module reopening.
+     * - It ensures initial settings, such as enabling `multiprice` by default and removing indexation in progress popup.
+     *   (See `FormManager` class, `postProcess` function)
+     * - It prevents the indexing popup from appearing when essential data, such as
+     *   `installation ID`, is missing, ensuring that indexing does not occur prematurely.
+     *
      * @return string The page's HTML content
      */
     public function getContent()
@@ -208,9 +216,21 @@ class DoofinderAdminPanelView
     }
 
     /**
-     * Render the data feed configuration form
+     * Render the data feed configuration form.
+     *
+     * The `skip` feature allows bypassing the onboarding screen and directly accessing the
+     * configuration page by appending `&skip=1` to the URL. Unlocks the fields for
+     * `installation ID`, `API Key`, and `region` like `&adv=1`.
+     *
+     * The differences of `&skip=1` and `&adv=1` are:
+     * - These fields can now be edited without requiring `&adv=1`, while the access to the
+     *   advanced tab remains restricted, as it is intended for the Support team.
+     * - The hashids section is now "transparent" for the customers and only becomes explicitly visible when
+     *   `&adv=1` is set, without being affected by `&skip=1`.
+     * - The `&skip=1` parameter persists during form submissions to maintain expected behavior.
      *
      * @param bool $adv
+     * @param bool $skip
      *
      * @return string
      */
@@ -512,7 +532,7 @@ class DoofinderAdminPanelView
                         2 => ['id' => 'ap1', 'name' => $this->module->l('Asia - Pacific', 'doofinderadminpanelview')],
                     ],
                     'id' => 'id',
-                    'name' => 'name'
+                    'name' => 'name',
                 ],
                 'disabled' => !$isAdvParamPresent && !$isManualInstallation,
             ],

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -459,6 +459,14 @@ class DoofinderAdminPanelView
                         'is_bool' => true,
                         'values' => $this->getBooleanFormValue(),
                     ],
+                    [
+                        'type' => (version_compare(_PS_VERSION_, '1.6.0', '>=') ? 'switch' : 'radio'),
+                        'label' => $this->module->l('Enable multicurrency', 'doofinderadminpanelview'),
+                        'name' => 'DF_MULTIPRICE_ENABLED',
+                        'desc' => $this->module->l('Do not change this option unless our support team has given you a specific guidance', 'doofinderadminpanelview'),
+                        'is_bool' => true,
+                        'values' => $this->getBooleanFormValue(),
+                    ],
                 ],
                 'submit' => [
                     'title' => $this->module->l('Save Internal Search Options', 'doofinderadminpanelview'),

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -646,16 +646,16 @@ class DoofinderApi
                         if ($dfOptions) {
                             $opt = json_decode($dfOptions, true);
                             if (isset($opt['query_limit_reached']) && $opt['query_limit_reached']) {
-                                $messagesArray['errorQueryLimit']['languages'][] = $langFullIso;
+                                $messagesArray['errorQueryLimit']['languages'][] = sprintf('(%s)', $langFullIso);
                             } else {
                                 $result = true;
                                 if ($isAdvParamPresent) {
-                                    $messagesArray['success']['languages'][] = $langFullIso;
+                                    $messagesArray['success']['languages'][] = sprintf('(%s)', $langFullIso);
                                 }
                             }
                         } else {
                             if ($isAdvParamPresent) {
-                                $messagesArray['errorNoConnection']['languages'][] = $langFullIso;
+                                $messagesArray['errorNoConnection']['languages'][] = sprintf('(%s)', $langFullIso);
                             }
                         }
                     } catch (DoofinderException $e) {
@@ -671,7 +671,7 @@ class DoofinderApi
                         $apiKeyMsgAlreadyShown = true;
                     }
                     if ($isAdvParamPresent && !$hashid) {
-                        $messagesArray['emptySearchEngine']['languages'][] = $langFullIso;
+                        $messagesArray['emptySearchEngine']['languages'][] = sprintf('(%s)', $langFullIso);
                     }
                 }
             }

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -656,7 +656,6 @@ class DoofinderApi
                         $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
                     }
                 }
-                
             }
         }
         if ($onlyOneLang) {

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -639,9 +639,17 @@ class DoofinderApi
                         $messages .= DoofinderAdminPanelView::displayErrorCtm($msg . $langFullIso);
                     }
                 } else {
-                    $msg = $module->l('Empty Api Key or empty Search Engine - ', 'doofinderapi') . $langFullIso;
-                    $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
+                    $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
+                    if (!$apiKey) {
+                        $msg = $module->l('Empty Api Key', 'doofinderapi');
+                        $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
+                    }
+                    if ($isAdvParamPresent && !$hashid) {
+                        $msg = $module->l('Empty Search Engine', 'doofinderapi') . '-' . $langFullIso;
+                        $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
+                    }
                 }
+                
             }
         }
         if ($onlyOneLang) {

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -614,7 +614,9 @@ class DoofinderApi
                 $langIso = \Tools::strtoupper($lang['iso_code']);
                 $langFullIso = (isset($lang['language_code'])) ? \Tools::strtoupper($lang['language_code']) : $langIso;
                 $hashid = \Configuration::get('DF_HASHID_' . $currency . '_' . $langFullIso);
+                $this->hashid = $hashid;
                 $apiKey = \Configuration::get('DF_API_KEY');
+                $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
                 if ($hashid && $apiKey) {
                     try {
                         $dfOptions = $this->getOptions();
@@ -625,12 +627,16 @@ class DoofinderApi
                                 $messages .= DoofinderAdminPanelView::displayErrorCtm($msg);
                             } else {
                                 $result = true;
-                                $msg = $module->l('Connection successful for Search Engine - ', 'doofinderapi') . $langFullIso;
-                                $messages .= DoofinderAdminPanelView::displayConfirmationCtm($msg);
+                                if ($isAdvParamPresent) {
+                                    $msg = $module->l('Connection successful for Search Engine - ', 'doofinderapi') . $langFullIso;
+                                    $messages .= DoofinderAdminPanelView::displayConfirmationCtm($msg);
+                                }
                             }
                         } else {
-                            $msg = $module->l('Error: no connection for Search Engine - ', 'doofinderapi') . $langFullIso;
-                            $messages .= DoofinderAdminPanelView::displayErrorCtm($msg);
+                            if ($isAdvParamPresent) {
+                                $msg = $module->l('Error: no connection for Search Engine - ', 'doofinderapi') . $langFullIso;
+                                $messages .= DoofinderAdminPanelView::displayErrorCtm($msg);
+                            }
                         }
                     } catch (DoofinderException $e) {
                         $messages .= DoofinderAdminPanelView::displayErrorCtm($e->getMessage() . ' - Search Engine ' . $langFullIso);
@@ -639,7 +645,6 @@ class DoofinderApi
                         $messages .= DoofinderAdminPanelView::displayErrorCtm($msg . $langFullIso);
                     }
                 } else {
-                    $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
                     if (!$apiKey) {
                         $msg = $module->l('Empty Api Key', 'doofinderapi');
                         $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -609,6 +609,7 @@ class DoofinderApi
         $messages = '';
         $currency = \Tools::strtoupper(\Context::getContext()->currency->iso_code);
         $context = \Context::getContext();
+        $apiKeyMsgAlreadyShown = false;
         foreach (\Language::getLanguages(true, $context->shop->id) as $lang) {
             if (!$onlyOneLang || ($onlyOneLang && $lang['iso_code'])) {
                 $langIso = \Tools::strtoupper($lang['iso_code']);
@@ -645,12 +646,13 @@ class DoofinderApi
                         $messages .= DoofinderAdminPanelView::displayErrorCtm($msg . $langFullIso);
                     }
                 } else {
-                    if (!$apiKey) {
+                    if (!$apiKeyMsgAlreadyShown && !$apiKey) {
                         $msg = $module->l('Empty Api Key', 'doofinderapi');
                         $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
+                        $apiKeyMsgAlreadyShown = true;
                     }
                     if ($isAdvParamPresent && !$hashid) {
-                        $msg = $module->l('Empty Search Engine', 'doofinderapi') . '-' . $langFullIso;
+                        $msg = $module->l('Empty Search Engine', 'doofinderapi') . ' - ' . $langFullIso;
                         $messages .= DoofinderAdminPanelView::displayWarningCtm($msg);
                     }
                 }

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -157,13 +157,12 @@ class DoofinderConfig
 
         $hashidKeys = DfTools::getHashidKeys();
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
-        $isManualInstallation = (bool) \Tools::getValue('skip', 0);
         $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
         $keyToUse = 'key';
         if ($multipriceEnabled) {
             $keyToUse = 'keyMultiprice';
         }
-        if ($isAdvParamPresent || $isManualInstallation) {
+        if ($isAdvParamPresent) {
             foreach ($hashidKeys as $hashidKey) {
                 // To avoid overriding already defined values in multiprice cases
                 if (!empty($config[$hashidKey[$keyToUse]])) {

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -154,12 +154,18 @@ class DoofinderConfig
             'DF_API_KEY' => \Configuration::get('DF_API_KEY'),
             'DF_REGION' => \Configuration::get('DF_REGION'),
         ];
+
         $hashidKeys = DfTools::getHashidKeys();
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
         $isManualInstallation = (bool) \Tools::getValue('skip', 0);
+        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
+        $keyToUse = 'key';
+        if ($multipriceEnabled) {
+            $keyToUse = 'keyMultiprice';
+        }
         if ($isAdvParamPresent || $isManualInstallation) {
             foreach ($hashidKeys as $hashidKey) {
-                $config[$hashidKey['key']] = \Configuration::get($hashidKey['key']);
+                $config[$hashidKey[$keyToUse]] = \Configuration::get($hashidKey['key']);
             }
         }
 

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -149,11 +149,21 @@ class DoofinderConfig
      */
     public static function getConfigFormValuesStoreInfo()
     {
-        return [
+        $config = [
             'DF_INSTALLATION_ID' => \Configuration::get('DF_INSTALLATION_ID'),
             'DF_API_KEY' => \Configuration::get('DF_API_KEY'),
             'DF_REGION' => \Configuration::get('DF_REGION'),
         ];
+        $hashidKeys = DfTools::getHashidKeys();
+        $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
+        $isManualInstallation = (bool) \Tools::getValue('skip', 0);
+        if ($isAdvParamPresent || $isManualInstallation) {
+            foreach ($hashidKeys as $hashidKey) {
+                $config[$hashidKey['key']] = \Configuration::get($hashidKey['key']);
+            }
+        }
+
+        return $config;
     }
 
     /**

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -165,6 +165,10 @@ class DoofinderConfig
         }
         if ($isAdvParamPresent || $isManualInstallation) {
             foreach ($hashidKeys as $hashidKey) {
+                // To avoid overriding already defined values in multiprice cases
+                if (!empty($config[$hashidKey[$keyToUse]])) {
+                    continue;
+                }
                 $config[$hashidKey[$keyToUse]] = \Configuration::get($hashidKey['key']);
             }
         }

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -139,6 +139,7 @@ class DoofinderConfig
             'DF_DEBUG' => \Configuration::get('DF_DEBUG'),
             'DF_DEBUG_CURL' => \Configuration::get('DF_DEBUG_CURL'),
             'DF_ENABLED_V9' => \Configuration::get('DF_ENABLED_V9'),
+            'DF_MULTIPRICE_ENABLED' => \Configuration::get('DF_MULTIPRICE_ENABLED', null, null, null, true),
         ];
     }
 

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -158,7 +158,7 @@ class DoofinderConfig
 
         $hashidKeys = DfTools::getHashidKeys();
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
-        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
+        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
         $keyToUse = 'key';
         if ($multipriceEnabled) {
             $keyToUse = 'keyMultiprice';

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -67,13 +67,28 @@ class DoofinderConfig
         $apiEndpointArray = explode('-', $apiEndpoint);
         $region = $apiEndpointArray[0];
 
+        \Configuration::updateValue('DF_REGION', $region, false, $shopGroupId, $shopId);
+        \Configuration::updateValue('DF_API_KEY', $region . '-' . $apiKey, false, $shopGroupId, $shopId);
+        self::setSharedDefaultConfig($shopGroupId, $shopId);
+    }
+
+    /**
+     * Set the default values that don't need the API Key to be calculated in the configuration.
+     * This function is useful for manual installations where the API key is not present until
+     * the user enters it manually.
+     *
+     * @param int $shopGroupId
+     * @param int $shopId
+     *
+     * @return void
+     */
+    public static function setSharedDefaultConfig($shopGroupId, $shopId)
+    {
         \Configuration::updateValue('DF_ENABLE_HASH', true, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_GS_DISPLAY_PRICES', true, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_GS_PRICES_USE_TAX', true, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_FEED_FULL_PATH', true, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_SHOW_PRODUCT_VARIATIONS', 0, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_REGION', $region, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_API_KEY', $region . '-' . $apiKey, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_GS_DESCRIPTION_TYPE', DoofinderConstants::GS_SHORT_DESCRIPTION, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_FEED_MAINCATEGORY_PATH', false, false, $shopGroupId, $shopId);
         \Configuration::updateValue('DF_GS_IMAGE_SIZE', key(DfTools::getAvailableImageSizes()), false, $shopGroupId, $shopId);

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -84,15 +84,25 @@ class DoofinderConfig
      */
     public static function setSharedDefaultConfig($shopGroupId, $shopId)
     {
-        \Configuration::updateValue('DF_ENABLE_HASH', true, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_GS_DISPLAY_PRICES', true, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_GS_PRICES_USE_TAX', true, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_FEED_FULL_PATH', true, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_SHOW_PRODUCT_VARIATIONS', 0, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_GS_DESCRIPTION_TYPE', DoofinderConstants::GS_SHORT_DESCRIPTION, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_FEED_MAINCATEGORY_PATH', false, false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_GS_IMAGE_SIZE', key(DfTools::getAvailableImageSizes()), false, $shopGroupId, $shopId);
-        \Configuration::updateValue('DF_MULTIPRICE_ENABLED', true, false, $shopGroupId, $shopId);
+        $defaultConfigs = self::getDefaultConfigData();
+        foreach ($defaultConfigs as $key => $value) {
+            \Configuration::updateValue($key, $value, false, $shopGroupId, $shopId);
+        }
+    }
+
+    /**
+     * Set the default values that don't need the API Key to be calculated in the configuration, but
+     * unlike `setSharedDefaultConfig` function, it sets fallback data globally, not at shop level nor
+     * shop group level.
+     *
+     * @return void
+     */
+    public static function setSharedGlobalDefaultConfig()
+    {
+        $defaultConfigs = self::getDefaultConfigData();
+        foreach ($defaultConfigs as $key => $value) {
+            \Configuration::updateGlobalValue($key, $value);
+        }
     }
 
     /**
@@ -204,5 +214,26 @@ class DoofinderConfig
 
         return $result && $result->originalResponse && isset($result->headers['code'])
             && (strpos($result->originalResponse, 'HTTP/2 200') || $result->headers['code'] == 200);
+    }
+
+    /**
+     * Gets the default config data as key-value pairs to
+     * keep the single source of truth.
+     *
+     * @return array
+     */
+    private static function getDefaultConfigData()
+    {
+        return [
+            'DF_ENABLE_HASH' => true,
+            'DF_GS_DISPLAY_PRICES' => true,
+            'DF_GS_PRICES_USE_TAX' => true,
+            'DF_FEED_FULL_PATH' => true,
+            'DF_SHOW_PRODUCT_VARIATIONS' => 0,
+            'DF_GS_DESCRIPTION_TYPE' => DoofinderConstants::GS_SHORT_DESCRIPTION,
+            'DF_FEED_MAINCATEGORY_PATH' => false,
+            'DF_GS_IMAGE_SIZE' => key(DfTools::getAvailableImageSizes()),
+            'DF_MULTIPRICE_ENABLED' => true,
+        ];
     }
 }

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -115,7 +115,7 @@ class DoofinderConfig
     {
         return [
             'DF_SHOW_LAYER' => \Configuration::get('DF_SHOW_LAYER', null, null, null, true),
-            'DF_GS_DISPLAY_PRICES' => \Configuration::get('DF_GS_DISPLAY_PRICES'),
+            'DF_GS_DISPLAY_PRICES' => \Configuration::get('DF_GS_DISPLAY_PRICES', null, null, null, true),
             'DF_GS_PRICES_USE_TAX' => \Configuration::get('DF_GS_PRICES_USE_TAX'),
             'DF_FEED_FULL_PATH' => \Configuration::get('DF_FEED_FULL_PATH'),
             'DF_SHOW_PRODUCT_VARIATIONS' => \Configuration::get('DF_SHOW_PRODUCT_VARIATIONS'),

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.13.0';
+    const VERSION = '5.0.1';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.0.1';
+    const VERSION = '5.0.2';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderInstallation.php
+++ b/src/Entity/DoofinderInstallation.php
@@ -104,6 +104,7 @@ class DoofinderInstallation
         if (!empty($shop_id)) {
             $shop = \Shop::getShop($shop_id);
             self::_createStore($shop);
+            DoofinderConfig::setSharedGlobalDefaultConfig();
 
             return;
         }
@@ -112,6 +113,7 @@ class DoofinderInstallation
         foreach ($shops as $shop) {
             self::_createStore($shop);
         }
+        DoofinderConfig::setSharedGlobalDefaultConfig();
     }
 
     /**

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -51,7 +51,12 @@ class FormManager
 
         if ($isFirstTime) {
             \Configuration::updateGlobalValue('DF_FEED_INDEXED', true);
-            \Configuration::updateGlobalValue('DF_MULTIPRICE_ENABLED', true);
+            $shops = \Shop::getShops();
+            foreach ($shops as $shop) {
+                $shopGroupId = $shop['id_shop_group'];
+                $shopId = $shop['id_shop'];
+                DoofinderConfig::setSharedDefaultConfig($shopGroupId, $shopId);
+            }
         }
 
         if ((bool) \Tools::isSubmit('submitDoofinderModuleLaunchReindexing')) {

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -46,6 +46,7 @@ class FormManager
         $context = \Context::getContext();
 
         $isFirstTime = (bool) \Tools::getValue('first_time', 0);
+        $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
         $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
 
         if ($isFirstTime) {
@@ -89,7 +90,7 @@ class FormManager
             }
             $value = trim($value);
             // Special case for Hashids due to the Multiprice
-            if ($multipriceEnabled && str_contains($postKey, 'DF_HASHID')) {
+            if ($isAdvParamPresent && $multipriceEnabled && str_contains($postKey, 'DF_HASHID')) {
                 self::updateHashIds($postKey, $value);
                 continue;
             }

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -50,13 +50,13 @@ class FormManager
         $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
 
         if ($isFirstTime) {
-            \Configuration::updateGlobalValue('DF_FEED_INDEXED', true);
             $shops = \Shop::getShops();
             foreach ($shops as $shop) {
                 $shopGroupId = $shop['id_shop_group'];
                 $shopId = $shop['id_shop'];
                 DoofinderConfig::setSharedDefaultConfig($shopGroupId, $shopId);
             }
+            DoofinderConfig::setSharedGlobalDefaultConfig();
         }
 
         if ((bool) \Tools::isSubmit('submitDoofinderModuleLaunchReindexing')) {

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -47,11 +47,11 @@ class FormManager
 
         $isFirstTime = (bool) \Tools::getValue('first_time', 0);
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
-        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED', false);
+        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
 
         if ($isFirstTime) {
-            \Configuration::updateValue('DF_FEED_INDEXED', true);
-            \Configuration::updateValue('DF_MULTIPRICE_ENABLED', true);
+            \Configuration::updateGlobalValue('DF_FEED_INDEXED', true);
+            \Configuration::updateGlobalValue('DF_MULTIPRICE_ENABLED', true);
         }
 
         if ((bool) \Tools::isSubmit('submitDoofinderModuleLaunchReindexing')) {

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -47,7 +47,6 @@ class FormManager
 
         $isFirstTime = (bool) \Tools::getValue('first_time', 0);
         $isAdvParamPresent = (bool) \Tools::getValue('adv', 0);
-        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
 
         if ($isFirstTime) {
             $shops = \Shop::getShops();
@@ -56,8 +55,11 @@ class FormManager
                 $shopId = $shop['id_shop'];
                 DoofinderConfig::setSharedDefaultConfig($shopGroupId, $shopId);
             }
+            \Configuration::updateGlobalValue('DF_FEED_INDEXED', true);
             DoofinderConfig::setSharedGlobalDefaultConfig();
         }
+
+        $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
 
         if ((bool) \Tools::isSubmit('submitDoofinderModuleLaunchReindexing')) {
             UpdateOnSave::indexApiInvokeReindexing();

--- a/src/Entity/UrlManager.php
+++ b/src/Entity/UrlManager.php
@@ -86,6 +86,11 @@ class UrlManager
         return self::getRegionalUrl(DoofinderConstants::DOOPLUGINS_REGION_URL, $region, '/prestashop/feed-url-update');
     }
 
+    public static function getEnableMultipriceUrl($region)
+    {
+        return self::getRegionalUrl(DoofinderConstants::DOOPLUGINS_REGION_URL, $region, '/prestashop/enable-multiprice');
+    }
+
     /**
      * Gets an URL with its region filled in. You can also append a path (optional).
      * If the region is provided as '' it will return a regionless URL.

--- a/src/Entity/UrlManager.php
+++ b/src/Entity/UrlManager.php
@@ -86,11 +86,6 @@ class UrlManager
         return self::getRegionalUrl(DoofinderConstants::DOOPLUGINS_REGION_URL, $region, '/prestashop/feed-url-update');
     }
 
-    public static function getEnableMultipriceUrl($region)
-    {
-        return self::getRegionalUrl(DoofinderConstants::DOOPLUGINS_REGION_URL, $region, '/prestashop/enable-multiprice');
-    }
-
     /**
      * Gets an URL with its region filled in. You can also append a path (optional).
      * If the region is provided as '' it will return a regionless URL.

--- a/translations/en.php
+++ b/translations/en.php
@@ -1,5 +1,6 @@
 <?php
 
+global $_MODULE;
 $_MODULE = [];
 $_MODULE['<{doofinder}prestashop>doofinder_dd31d974a78cdd704acaa6bf15da506c'] = 'Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinder_537d60a5ce0c6b6cf2d6790d5b38b93f'] = 'Install Doofinder in your shop with no effort';
@@ -31,6 +32,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Debug CURL error response';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'To debug if your server has symptoms of connection problems';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Doofinder script in mobile version';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_fe8f8482b64a14a0b5514d5654de56b8'] = 'Enable multicurrency';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_5158d161ee2c6900a2fd2c45e97a6908'] = 'Do not change this option unless our support team has given you a specific guidance';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_48c07cbd1f0f4b03d59befc3e72e9b87'] = 'Save Internal Search Options';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe8357f5e18a56'] = 'Doofinder Store ID';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'You can find this identifier in our control panel. Inside the side menu labeled \"Store settings\".';

--- a/translations/en.php
+++ b/translations/en.php
@@ -1,6 +1,5 @@
 <?php
 
-global $_MODULE;
 $_MODULE = [];
 $_MODULE['<{doofinder}prestashop>doofinder_dd31d974a78cdd704acaa6bf15da506c'] = 'Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinder_537d60a5ce0c6b6cf2d6790d5b38b93f'] = 'Install Doofinder in your shop with no effort';
@@ -29,8 +28,6 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_acc697e9b9f3dae4b46e08f
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_cf565402d32b79d33f626252949a6941'] = 'Save configuration';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_9dfc5d5738312210c3c75e68a468691d'] = 'Advanced Options';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38461ba2356'] = 'Debug Mode. Write info logs in doofinder.log file';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b0939b990335e5c6a8f76fa5c81835b3'] = 'CURL disable HTTPS check';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_958cf5c1405c86e460b294803caedc45'] = 'If your server have an untrusted certificate and you have connection problems with the API, please enable this';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Debug CURL error response';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'To debug if your server has symptoms of connection problems';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Doofinder script in mobile version';
@@ -39,6 +36,10 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe835
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'You can find this identifier in our control panel. Inside the side menu labeled \"Store settings\".';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_e0daaf59114081fac112928e638c8d85'] = 'Doofinder Api Key';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f447ac856e7e72435904956e3b15f433'] = 'Region';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_912d59cdf1d3f551fae21f6f0062258f'] = 'Europe';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f253efe302d32ab264a76e0ce65be769'] = 'United States';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b76537b9476bbfd7f7ab2c1f2d33f6c4'] = 'Asia - Pacific';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_56ed20387ac80a77f5e50a52f2baa976'] = 'Hashid for Search Engine';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_08c1cf7707bb72744cd07192c8580580'] = 'Feed URLs to use on Doofinder Admin panel';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_80a11d2a54a677f6fadd9c041c0d6b98'] = 'Store Information';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_41bfb72cd54183db3f00393c9a052495'] = 'Save Store Info Widget Options';
@@ -47,7 +48,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_4c48400a2f3c25d9ee65425
 $_MODULE['<{doofinder}prestashop>doofinderapi_8412280eb3a42b954b37c5a5549f292e'] = 'Error: Credentials OK but limit query reached for Search Engine - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_e43b9767da79f0184ebaa0e9d5abed3e'] = 'Connection successful for Search Engine - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_cfa4587136de2d97cdb650add327f593'] = 'Error: no connection for Search Engine - ';
-$_MODULE['<{doofinder}prestashop>doofinderapi_24fd2c7b489981c568b971ac3178f5df'] = 'Empty Api Key or empty Search Engine - ';
+$_MODULE['<{doofinder}prestashop>doofinderapi_a6d588a0cb186e29ec7250b0d171fd62'] = 'Empty Api Key';
+$_MODULE['<{doofinder}prestashop>doofinderapi_6efd49d043658d2cf2d1836ebbd586a7'] = 'Empty Search Engine';
 $_MODULE['<{doofinder}prestashop>formmanager_fcea235fdf24a526070153f5b60355f4'] = 'You\'ve just changed a data feed option. It may be necessary to reprocess the index to apply these changes effectively.';
 $_MODULE['<{doofinder}prestashop>formmanager_2378c5bcb7b183304da2a2b94262f024'] = 'Launch reindexing';
 $_MODULE['<{doofinder}prestashop>formmanager_039b452cd9646bf1a60dd09146311ee7'] = 'Settings updated!';
@@ -58,7 +60,6 @@ $_MODULE['<{doofinder}prestashop>support_tab_6b8f482bb34c8983f0bcb2651b776e9f'] 
 $_MODULE['<{doofinder}prestashop>support_tab_105dad09bf429ff180f1465aba5b2164'] = 'How to configure the search layer filters';
 $_MODULE['<{doofinder}prestashop>support_tab_57efee3b429d91cddf66edbe6efb9b87'] = 'Learn the basics about Live Layer';
 $_MODULE['<{doofinder}prestashop>support_tab_f52757c491e99a76cb21926a04bd1c73'] = 'Or contact directly with us. We will be glad to help you';
-$_MODULE['<{doofinder}prestashop>support_tab_6dcce363217b8653bba30f4edf38ded4'] = 'Support email';
 $_MODULE['<{doofinder}prestashop>configure_ba0801f239c99cb689010161d3ee1471'] = 'On Boarding';
 $_MODULE['<{doofinder}prestashop>configure_8cd892b7b97ef9489ae4479d3f4ef0fc'] = 'store';
 $_MODULE['<{doofinder}prestashop>configure_db5eb84117d06047c97c9a0191b5fffe'] = 'Support';

--- a/translations/es.php
+++ b/translations/es.php
@@ -32,6 +32,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Depurar respuesta de error en el CURL';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'Para depurar si tu servidor tiene problemas de conexión';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Script de Doofinder en versión móvil';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_fe8f8482b64a14a0b5514d5654de56b8'] = 'Habilitar multidivisa';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_5158d161ee2c6900a2fd2c45e97a6908'] = 'No cambies esta opción a menos que nuestro equipo de soporte te lo indicado';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_48c07cbd1f0f4b03d59befc3e72e9b87'] = 'Guardar opciones de búsqueda interna';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe8357f5e18a56'] = 'Store ID de Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'Puedes encontrar este identificador en nuestro Panel de Control, dentro del menú superior etiquetado como \"Store settings\"';

--- a/translations/es.php
+++ b/translations/es.php
@@ -29,8 +29,6 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_acc697e9b9f3dae4b46e08f
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_cf565402d32b79d33f626252949a6941'] = 'Guardar la configuración';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_9dfc5d5738312210c3c75e68a468691d'] = 'Opciones Avanzadas';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38461ba2356'] = 'Modo depuración. Escribe logs de información en el fichero doofinder.log';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b0939b990335e5c6a8f76fa5c81835b3'] = 'Desactivar comprobación HTTPS en el CURL';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_958cf5c1405c86e460b294803caedc45'] = 'Si tu servidor tiene un certificado inválido y tienes problemas con la API, por favor activa esto';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Depurar respuesta de error en el CURL';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'Para depurar si tu servidor tiene problemas de conexión';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Script de Doofinder en versión móvil';
@@ -39,6 +37,10 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe835
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'Puedes encontrar este identificador en nuestro Panel de Control, dentro del menú superior etiquetado como \"Store settings\"';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_e0daaf59114081fac112928e638c8d85'] = 'Doofinder Api Key';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f447ac856e7e72435904956e3b15f433'] = 'Región';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_912d59cdf1d3f551fae21f6f0062258f'] = 'Europa';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f253efe302d32ab264a76e0ce65be769'] = 'Estados Unidos';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b76537b9476bbfd7f7ab2c1f2d33f6c4'] = 'Asia - Pacífico';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_56ed20387ac80a77f5e50a52f2baa976'] = 'Hashid del Motor de búsqueda';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_08c1cf7707bb72744cd07192c8580580'] = 'URLs de los feed para usar en el panel de administración de Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_80a11d2a54a677f6fadd9c041c0d6b98'] = 'Información de la tienda';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_41bfb72cd54183db3f00393c9a052495'] = 'Guardar información de la tienda';
@@ -47,7 +49,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_4c48400a2f3c25d9ee65425
 $_MODULE['<{doofinder}prestashop>doofinderapi_8412280eb3a42b954b37c5a5549f292e'] = 'Error: Las credenciales son correctas pero se alcanzó el límite de consultas para el motor de búsqueda - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_e43b9767da79f0184ebaa0e9d5abed3e'] = 'Conexión exitosa para el motor de búsqueda - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_cfa4587136de2d97cdb650add327f593'] = 'Error: no hay conexión para el motor de búsqueda - ';
-$_MODULE['<{doofinder}prestashop>doofinderapi_24fd2c7b489981c568b971ac3178f5df'] = 'Clave API vacía o motor de búsqueda vacío - ';
+$_MODULE['<{doofinder}prestashop>doofinderapi_a6d588a0cb186e29ec7250b0d171fd62'] = 'Clave API vacía';
+$_MODULE['<{doofinder}prestashop>doofinderapi_6efd49d043658d2cf2d1836ebbd586a7'] = 'Motor de búsqueda vacío';
 $_MODULE['<{doofinder}prestashop>formmanager_fcea235fdf24a526070153f5b60355f4'] = 'Acabas de cambiar una opción del feed de datos. Es posible que para aplicar estos cambios de manera efectiva sea necesario volver a procesar el índice.';
 $_MODULE['<{doofinder}prestashop>formmanager_2378c5bcb7b183304da2a2b94262f024'] = 'Lanzar reindexación';
 $_MODULE['<{doofinder}prestashop>formmanager_039b452cd9646bf1a60dd09146311ee7'] = 'La configuración se guardó correctamente.';
@@ -58,7 +61,6 @@ $_MODULE['<{doofinder}prestashop>support_tab_6b8f482bb34c8983f0bcb2651b776e9f'] 
 $_MODULE['<{doofinder}prestashop>support_tab_105dad09bf429ff180f1465aba5b2164'] = 'Cómo configurar los filtros de la capa de búsqueda';
 $_MODULE['<{doofinder}prestashop>support_tab_57efee3b429d91cddf66edbe6efb9b87'] = 'Cónoce los básicos sobre Live Layer';
 $_MODULE['<{doofinder}prestashop>support_tab_f52757c491e99a76cb21926a04bd1c73'] = 'O contacta directamente con nosotros. Estaremos encantados de ayudarte.';
-$_MODULE['<{doofinder}prestashop>support_tab_6dcce363217b8653bba30f4edf38ded4'] = 'Email de soporte';
 $_MODULE['<{doofinder}prestashop>configure_ba0801f239c99cb689010161d3ee1471'] = 'Comenzando';
 $_MODULE['<{doofinder}prestashop>configure_8cd892b7b97ef9489ae4479d3f4ef0fc'] = 'tienda';
 $_MODULE['<{doofinder}prestashop>configure_db5eb84117d06047c97c9a0191b5fffe'] = 'Soporte';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -32,6 +32,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Réponse d’erreur CURL en mode débogage';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'Pour déboguer si votre serveur présente des symptômes de problèmes de connexion';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Script de Doofinder dans la version mobile';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_fe8f8482b64a14a0b5514d5654de56b8'] = 'Activer le multidevise';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_5158d161ee2c6900a2fd2c45e97a6908'] = 'Ne modifiez pas cette option à moins que notre équipe d\'assistance ne vous ait fourni des instructions spécifiques';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_48c07cbd1f0f4b03d59befc3e72e9b87'] = 'Sauvegarder les options de recherche interne';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe8357f5e18a56'] = 'ID de magasin Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'Vous trouverez cet identifiant dans votre Panel de Contrôle, sous le menu \"Live Layer\"';

--- a/translations/fr.php
+++ b/translations/fr.php
@@ -29,8 +29,6 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_acc697e9b9f3dae4b46e08f
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_cf565402d32b79d33f626252949a6941'] = 'Sauvegarder la configuration';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_9dfc5d5738312210c3c75e68a468691d'] = 'Options Avancées';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f4f6f81745dcb96aaf1cd38461ba2356'] = 'Mode Débogage. Écrire les journaux d’informations dans le fichier doofinder.log';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b0939b990335e5c6a8f76fa5c81835b3'] = 'Désactiver la vérification HTTPS CURL';
-$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_958cf5c1405c86e460b294803caedc45'] = 'Si votre serveur dispose d’un certificat non fiable et que vous rencontrez des problèmes de connexion avec l’API, veuillez activer ceci';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_bfa398fb4ff673ac66baeedbc80f0b77'] = 'Réponse d’erreur CURL en mode débogage';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_170246e7e517d7cd317e3a6ae3ebcb4c'] = 'Pour déboguer si votre serveur présente des symptômes de problèmes de connexion';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_ae21e0ee96b018923d90e29d3550a56c'] = 'Script de Doofinder dans la version mobile';
@@ -39,6 +37,10 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_79958197e198decc81fe835
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_27b4149f9ec9505a33aded4775a47104'] = 'Vous trouverez cet identifiant dans votre Panel de Contrôle, sous le menu \"Live Layer\"';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_e0daaf59114081fac112928e638c8d85'] = 'Clé API de Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f447ac856e7e72435904956e3b15f433'] = 'Région';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_912d59cdf1d3f551fae21f6f0062258f'] = 'Europe';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_f253efe302d32ab264a76e0ce65be769'] = 'États-Unis';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_b76537b9476bbfd7f7ab2c1f2d33f6c4'] = 'Asie-Pacifique';
+$_MODULE['<{doofinder}prestashop>doofinderadminpanelview_56ed20387ac80a77f5e50a52f2baa976'] = 'Hashid pour le moteur de recherche';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_08c1cf7707bb72744cd07192c8580580'] = 'Voici vos Url de flux produit à insérer dans le back office de Doofinder';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_80a11d2a54a677f6fadd9c041c0d6b98'] = 'Informations sur le magasin';
 $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_41bfb72cd54183db3f00393c9a052495'] = 'Sauvegarder les options du widget d\'informations sur le magasin';
@@ -47,7 +49,8 @@ $_MODULE['<{doofinder}prestashop>doofinderadminpanelview_4c48400a2f3c25d9ee65425
 $_MODULE['<{doofinder}prestashop>doofinderapi_8412280eb3a42b954b37c5a5549f292e'] = 'Erreur : les informations d\'identification sont correctes mais la limite de requête est atteinte pour le moteur de recherche - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_e43b9767da79f0184ebaa0e9d5abed3e'] = 'Connexion réussie pour le moteur de recherche - ';
 $_MODULE['<{doofinder}prestashop>doofinderapi_cfa4587136de2d97cdb650add327f593'] = 'Erreur : aucune connexion pour le moteur de recherche - ';
-$_MODULE['<{doofinder}prestashop>doofinderapi_24fd2c7b489981c568b971ac3178f5df'] = 'Clé API vide ou moteur de recherche vide - ';
+$_MODULE['<{doofinder}prestashop>doofinderapi_a6d588a0cb186e29ec7250b0d171fd62'] = 'Clé API vide';
+$_MODULE['<{doofinder}prestashop>doofinderapi_6efd49d043658d2cf2d1836ebbd586a7'] = 'Moteur de recherche vide';
 $_MODULE['<{doofinder}prestashop>formmanager_fcea235fdf24a526070153f5b60355f4'] = 'Vous venez de modifier une option de flux de données. Il peut être nécessaire de retraiter l\'index pour appliquer efficacement ces modifications.';
 $_MODULE['<{doofinder}prestashop>formmanager_2378c5bcb7b183304da2a2b94262f024'] = 'Lancer la réindexation';
 $_MODULE['<{doofinder}prestashop>formmanager_039b452cd9646bf1a60dd09146311ee7'] = 'Paramètres mis à jour !';
@@ -58,7 +61,6 @@ $_MODULE['<{doofinder}prestashop>support_tab_6b8f482bb34c8983f0bcb2651b776e9f'] 
 $_MODULE['<{doofinder}prestashop>support_tab_105dad09bf429ff180f1465aba5b2164'] = 'Comment configurer les filtres de la couche de recherche';
 $_MODULE['<{doofinder}prestashop>support_tab_57efee3b429d91cddf66edbe6efb9b87'] = 'Apprendre les bases de Live Layer';
 $_MODULE['<{doofinder}prestashop>support_tab_f52757c491e99a76cb21926a04bd1c73'] = 'Ou contacter directement notre support, nous serons ravis de vous guider';
-$_MODULE['<{doofinder}prestashop>support_tab_6dcce363217b8653bba30f4edf38ded4'] = 'Mail de notre support';
 $_MODULE['<{doofinder}prestashop>configure_ba0801f239c99cb689010161d3ee1471'] = 'ON BOARDING';
 $_MODULE['<{doofinder}prestashop>configure_8cd892b7b97ef9489ae4479d3f4ef0fc'] = 'boutique';
 $_MODULE['<{doofinder}prestashop>configure_db5eb84117d06047c97c9a0191b5fffe'] = 'SUPPORT';

--- a/views/js/admin-panel.js
+++ b/views/js/admin-panel.js
@@ -62,7 +62,21 @@ $(document).ready(function() {
       return;
     }
     const region = apiKey.split('-').shift();
+    const previousRegion = $regionNode.val();
     $regionNode.val(region);
+    
+    if (previousRegion === region) {
+      return;
+    }
+
+    // Small animation to catch user attention
+    $regionNode.animate({
+      opacity:"0.5"
+    }, 1000, function() {
+      $regionNode.animate({
+        opacity:"1"
+      }, 1000);
+    });
   });
 
 });

--- a/views/js/admin-panel.js
+++ b/views/js/admin-panel.js
@@ -32,7 +32,7 @@ $(document).ready(function() {
     var value = $(trigeringElementOnId).is(':checked');
     var parent = getParent(targetElementId);
 
-    if (value ) {
+    if (value) {
       parent.show()
     } else {
       parent.hide();
@@ -51,13 +51,18 @@ $(document).ready(function() {
     return parent;
   }
 
-  $('#DF_API_KEY').on('change', function() {
-    const apiKey = $('#DF_API_KEY').val().trim();
+  const $apiKeyNode = $('#DF_API_KEY');
+  const $regionNode = $('#DF_REGION');
+  $apiKeyNode.on('change', function() {
+    if (0 === $apiKeyNode.length || 0 === $regionNode.length) {
+      return;
+    }
+    const apiKey = $apiKeyNode.val().trim();
     if (!/eu1-|ap1-|us1-/.test(apiKey)) {
       return;
     }
     const region = apiKey.split('-').shift();
-    $('#DF_REGION').val(region);
+    $regionNode.val(region);
   });
 
 });

--- a/views/js/admin-panel.js
+++ b/views/js/admin-panel.js
@@ -51,4 +51,13 @@ $(document).ready(function() {
     return parent;
   }
 
+  $('#DF_API_KEY').on('change', function() {
+    const apiKey = $('#DF_API_KEY').val().trim();
+    if (!/eu1-|ap1-|us1-/.test(apiKey)) {
+      return;
+    }
+    const region = apiKey.split('-').shift();
+    $('#DF_REGION').val(region);
+  });
+
 });

--- a/views/templates/admin/onboarding_tab.tpl
+++ b/views/templates/admin/onboarding_tab.tpl
@@ -71,6 +71,7 @@
 				</div>
 				<div class="col-md-12" style="margin-top:35px">
 					<p>
+						{* Go to DoofinderAdminPanelView class to see the details about the formation of the $skipurl *}
 						<a href="{html_entity_decode($skipurl|escape:'htmlall':'UTF-8')}" style="font-size: 10px;font-style: italic;">{l s='I want to skip the autoinstaller, take me to the module manual configuration.' mod='doofinder'}</a>
 					</p>
 				</div>


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-prestashop/issues/261

Basically this PR allows users to enter manual information if the want to connect manually the module with an already existing store in Doomanager. In order to do so, there are now 3 types of users:

- Regular user with automated installation: The installation wizard will fill in automatically all the required fields after the user has logged in into Doofinder, so the installation-related fields like Installation ID, Region and API Key will be read-only or disabled.
- Regular user with manual installation: The param `&skip=1` will be added to the URL after the installation has finished so the user will be able to enter all the details manually. However, the Search Engines will be calculated automatically through the Installation ID after the user has set up the Update On Save
- Advanced user (Support team): Apart from the previous privileges, this user will be allowed to define manually the Search Engines, just in case they want to apply some specific overrides (mostly for testing purposes). They are also granted to access the Advanced tab, where they might disable the multicurrency for those stores which have been created prior to the release of the multicurrency feature.