### PR TITLE
Making sure only variants from the same shop are included in the feed

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.13.0';
+        $this->version = '4.13.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -716,7 +716,7 @@ class DfTools
           ON (p.id_product = pa.id_product)
         LEFT JOIN _DB_PREFIX_product_supplier psp
           ON (p.id_product = psp.id_product AND pa.id_product_attribute = psp.id_product_attribute)
-        LEFT JOIN _DB_PREFIX_product_attribute_shop pas
+        INNER JOIN _DB_PREFIX_product_attribute_shop pas
           ON (pas.id_product_attribute = pa.id_product_attribute AND pas.id_shop = _ID_SHOP_)
         LEFT JOIN _DB_PREFIX_product_attribute_image pa_im
           ON (pa_im.id_product_attribute = pa.id_product_attribute)

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.13.0';
+    const VERSION = '4.13.1';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Fixes https://github.com/doofinder/support/issues/3293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved product variant displays by refining the filtering criteria. Now, only variants with complete attribute data will be shown, enhancing overall data consistency and reliability.
  
- **Chores**
  - Updated Doofinder module version from 4.13.0 to 4.13.1.
  - Updated VERSION constant in DoofinderConstants from '4.13.0' to '4.13.1'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->