### PR TITLE
PLUGINRANGERS-213 | Fixed single error messages visualization

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.13.2';
+        $this->version = '4.13.3';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.13.2';
+    const VERSION = '4.13.3';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/views/js/doofinder-onboarding.js
+++ b/views/js/doofinder-onboarding.js
@@ -77,13 +77,14 @@ function launchAutoinstaller() {
       //reload without resending post data
       history.go(0);
     } else {
-      if (data.errors && data.errors.length > 0) {
+      if ("string" === typeof data.errors) {
+        $(".loading-installer").hide();
+        $("#installation-errors").append("<li>" + data.errors + "</li>");
+      } else if (data.errors && data.errors.length > 0) {
         $(".loading-installer").hide();
         for (const error in data.errors) {
           if (Object.hasOwnProperty.call(data.errors, error)) {
-            $("#installation-errors").append(
-              "<li>" + data.errors[error] + "</li>"
-            );
+            $("#installation-errors").append("<li>" + data.errors[error] + "</li>");
           }
         }
       }


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-prestashop/issues/213

Until now single error messages were being treated as arrays. Since strings are also internally arrays of chars we were iterating through each single character, thus showing it with a character per bullet point.

Before:

![image](https://github.com/user-attachments/assets/b6644dc5-77f4-4808-bb15-23c1b9da2161)


After:

![image](https://github.com/user-attachments/assets/15ef1e84-3b12-44ac-8508-cb163c45412f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the module version to 4.13.3.
- **Bug Fixes**
	- Streamlined error feedback during installation to ensure clear, consistent messaging regardless of the error format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->