### PR TITLE
PLUGINRANGERS-3335 | Fixed SQL query + minor warnings fix

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '4.13.3';
+        $this->version = '4.13.4';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -273,11 +273,11 @@ $rows = DfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $
 $rows = arrayMergeByIdProduct($rows, $extra_rows);
 
 // In case there is no need to display prices, avoid calculating the mins by variant
-$min_price_variant_by_product_id = $cfg_display_prices ? DfTools::getMinVariantPrices($rows, $cfg_prices_w_taxes, $currencies, $lang->id, $shop->id) : [];
+$min_price_variant_by_product_id = ($cfg_product_variations && $cfg_display_prices) ? DfTools::getMinVariantPrices($rows, $cfg_prices_w_taxes, $currencies, $lang->id, $shop->id) : [];
 
 foreach ($rows as $row) {
     $product_id = $row['id_product'];
-    if (DfTools::isParent($row)) {
+    if (!$cfg_product_variations || DfTools::isParent($row)) {
         $variant_id = null;
     } else {
         $variant_id = $row['id_product_attribute'];

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -558,7 +558,7 @@ class DfTools
             UNION
             SELECT
                 ps.id_product,
-                (SELECT COUNT(*) FROM ps_product prod LEFT OUTER JOIN ps_product_attribute pa
+                (SELECT COUNT(*) FROM _DB_PREFIX_product prod LEFT OUTER JOIN _DB_PREFIX_product_attribute pa
                 ON (prod.id_product = pa.id_product) WHERE prod.id_product = p.id_product) AS variant_count,
                 ps.show_price,
                 0,

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -716,7 +716,7 @@ class DfTools
           ON (p.id_product = pa.id_product)
         LEFT JOIN _DB_PREFIX_product_supplier psp
           ON (p.id_product = psp.id_product AND pa.id_product_attribute = psp.id_product_attribute)
-        LEFT JOIN _DB_PREFIX_product_attribute_shop pas
+        INNER JOIN _DB_PREFIX_product_attribute_shop pas
           ON (pas.id_product_attribute = pa.id_product_attribute AND pas.id_shop = _ID_SHOP_)
         LEFT JOIN _DB_PREFIX_product_attribute_image pa_im
           ON (pa_im.id_product_attribute = pa.id_product_attribute)

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -27,7 +27,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '4.13.3';
+    const VERSION = '4.13.4';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3335

The query for variants was assuming in a statement that ps_ will be used always, but since the customer can change it, we cannot trust on it, so now the placeholder has been used instead.

Apart from this, we have prevented min price calculations if the variants are disabled to prevent this silenced warning:

```html
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1376</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1573</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1376</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1573</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1376</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1573</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1376</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1573</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1376</b><br />
<br />
<b>Warning</b>:  Undefined array key "id_product_attribute" in <b>/var/www/html/sites/manu_martin2/charlie-et-suzie-202.s192272.com/html/modules/doofinder/src/Entity/DfTools.php</b> on line <b>1573</b><br />
<br />
```