### PR TITLE
To be able to modify and adapt to product rows

### DIFF
--- a/feeds/product.php
+++ b/feeds/product.php
@@ -246,9 +246,15 @@ $header = array_merge($header, $additionalAttributesHeaders);
  * )
  * As each module can extend $extraHeader and $extraRows don't forget to merge them
  */
+
+ // PRODUCTS
+$rows = DfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
+
 $extraHeader = [];
 $extraRows = [];
+
 Hook::exec('actionDoofinderExtendFeed', [
+    'rows' => &$rows,
     'extra_header' => &$extraHeader,
     'extra_rows' => &$extraRows,
     'id_lang' => $lang->id,
@@ -260,9 +266,6 @@ Hook::exec('actionDoofinderExtendFeed', [
 $header = array_merge($header, $extraHeader);
 // To avoid indexation failures
 $header = array_unique($header);
-
-// PRODUCTS
-$rows = DfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
 
 $rows = arrayMergeByIdProduct($rows, $extraRows);
 


### PR DESCRIPTION
I'd like to be able to **modify the rows** before they're displayed in the doofinder feed, but also when you add extra columns via the `actionDoofinderExtendFeed `hook, you can't tell exactly what they're for.

With this method, it's possible and has no impact on the code.

**For example :**
```
public function hookActionDoofinderExtendFeed(array $params): void
{
	$productIds = array_column($params['rows'], 'id_product');
	$params['extra_header'][] = 'extra_column';

	foreach ($productIds as $productId) {
		$params['extra_rows'][] = [
			'id_product' => $productId,
			'extra_column' => 0,
		];
	}
}
```