### PR TITLE
PLUGINRANGERS-3392 | Fixed compatibility with older PHP versions + checked array

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v4
 
       - name: PHP syntax checker 5.4
         uses: prestashop/github-action-php-lint/5.4@master

--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.1.1';
+        $this->version = '5.1.2';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => _PS_VERSION_];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -272,12 +272,12 @@ $additionalHeaders = array_merge($additionalAttributesHeaders, $extraHeader);
 
 $csv = fopen('php://output', 'w');
 if (!$limit || (false !== $offset && 0 === (int) $offset)) {
-    fputcsv($csv, $header, DfTools::TXT_SEPARATOR, '"', '');
+    fputcsv($csv, $header, DfTools::TXT_SEPARATOR);
 }
 
 foreach ($rows as $row) {
     $product = $dfProductBuild->buildProduct($row, $minPriceVariantByProductId, $additionalAttributesHeaders, $additionalHeaders);
     $product = $dfProductBuild->applySpecificTransformationsForCsv($product, $extraHeader, $header);
-    fputcsv($csv, $product, DfTools::TXT_SEPARATOR, '"', '');
+    fputcsv($csv, $product, DfTools::TXT_SEPARATOR);
 }
 fclose($csv);

--- a/src/Entity/DfProductBuild.php
+++ b/src/Entity/DfProductBuild.php
@@ -315,7 +315,7 @@ class DfProductBuild
             $product['df_variants_information'] = implode('%%', array_map([__NAMESPACE__ . '\DfTools', 'slugify'], $product['df_variants_information']));
         }
 
-        $product['df_group_leader'] = (array_key_exists('df_group_leader', $product)) ? (int) $product['df_group_leader'] : DoofinderConstants::NO;
+        $product['df_group_leader'] = (is_array($product) && array_key_exists('df_group_leader', $product)) ? (int) $product['df_group_leader'] : DoofinderConstants::NO;
 
         if (array_key_exists('features', $product) && is_array($product['features'])) {
             $formattedAttributes = [];

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1108,6 +1108,7 @@ class DfTools
         $text = trim($text);
         $text = preg_replace('/^["\']+/', '', $text); // remove first quotes
         $text = str_replace(self::TXT_SEPARATOR, '&#124;', $text);
+        $text = stripcslashes($text);
 
         return preg_replace(self::VALID_UTF8, '$1', $text);
     }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1647,7 +1647,7 @@ class DfTools
     public static function str_contains($haystack, $needle)
     {
         if (function_exists('str_contains')) {
-            return str_contains($haystack, $needle);
+            return \str_contains($haystack, $needle);
         }
 
         return '' === $needle || false !== strpos($haystack, $needle);

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1644,6 +1644,15 @@ class DfTools
         return \Cache::retrieve($cacheKey);
     }
 
+    public static function str_contains($haystack, $needle)
+    {
+        if (function_exists('str_contains')) {
+            return str_contains($haystack, $needle);
+        }
+
+        return '' === $needle || false !== strpos($haystack, $needle);
+    }
+
     private static function getVariantUrl($product, $context)
     {
         $context = \Context::getContext();

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -28,7 +28,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.1';
+    const VERSION = '5.1.2';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -98,7 +98,7 @@ class FormManager
             }
             $value = trim($value);
             // Special case for Hashids due to the Multiprice
-            if ($isAdvParamPresent && $multipriceEnabled && str_contains($postKey, 'DF_HASHID')) {
+            if ($isAdvParamPresent && $multipriceEnabled && DfTools::str_contains($postKey, 'DF_HASHID')) {
                 self::updateHashIds($postKey, $value);
                 continue;
             }


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/3392

It turns out that `str_contains` was introduced in PHP 8.