### PR TITLE
PLUGINRANGERS-310 | Wrong variable name + excluded unneeded files from ZIP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,4 +6,6 @@
 /\.travis\.yml        export-ignore
 /build\.sh            export-ignore
 /\.github		      export-ignore
+/\.vscode		      export-ignore
+/\.php-cs-fixer\.dist\.php	    export-ignore
 /prestashop_architecture\.md	export-ignore

--- a/controllers/front/feed.php
+++ b/controllers/front/feed.php
@@ -56,7 +56,7 @@ class DoofinderFeedModuleFrontController extends ModuleFrontController
             $this->ajaxDie($feed);
         } else {
             // Workaround for PS 1.5
-            echo $jsonCfg;
+            echo $feed;
             exit;
         }
     }


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-prestashop/issues/310 (it's a bugfix for this PR too)