### PR TITLE
Feed query update

### DIFF
--- a/feeds/product.php
+++ b/feeds/product.php
@@ -433,7 +433,7 @@ if(isset($_GET["old"]) && $_GET["old"] == 1) {
 
 
     $products = DfTools::getAvailableProductsForLanguageV2($lang->id, $shouldShowProductVariations, $limit, $offset);
-    $empty_line = array_fill_keys($header,null);
+    $empty_line = array_fill_keys($header, null);
     foreach ($products as $product) {
         $minProductPrices = [];
         if ($shouldShowProductVariations && $product['variant_count'] > 0) {
@@ -451,7 +451,7 @@ if(isset($_GET["old"]) && $_GET["old"] == 1) {
                 fputcsv($csv, $csv_product, DfTools::TXT_SEPARATOR, '"', '');
             }
             $product = $dfProductBuild->buildProduct($product, [$product['id_product'] => $minProductPrices], $additionalAttributesHeaders, $additionalHeaders);
-        } else{
+        } else {
             $product = $dfProductBuild->buildProduct($product, [], $additionalAttributesHeaders, $additionalHeaders);
         }
 

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -448,7 +448,7 @@ if(isset($_GET["old"]) && $_GET["old"] == 1) {
                 $expanded_variation = array_merge($product, $variation);
                 $built_variation = $dfProductBuild->buildProduct($expanded_variation, [], $additionalAttributesHeaders, $additionalHeaders);
                 $csv_product = $dfProductBuild->applySpecificTransformationsForCsv($built_variation, $extraHeader, $header);
-                fputcsv($csv, $csv_product, DfTools::TXT_SEPARATOR, '"', '');
+                fputcsv($csv, $csv_product, DfTools::TXT_SEPARATOR);
             }
             $product = $dfProductBuild->buildProduct($product, [$product['id_product'] => $minProductPrices], $additionalAttributesHeaders, $additionalHeaders);
         } else {

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -38,150 +38,6 @@ if (function_exists('set_time_limit')) {
 
 DfTools::validateSecurityToken(Tools::getValue('dfsec_hash'));
 
-/**
- * Global storage for all active measurements.
- *   - $__metrics_data[$label] holds ['time' => float, 'memory' => int, 'peak' => int]
- *   - $__metrics_stack is an indexed array of labels, used to pop the most recent.
- */
-$__metrics_data  = [];
-$__metrics_stack = [];
-
-/**
- * Begin measuring time & memory.
- *
- * @param string|null $label  Optional: a custom label for this measurement.
- *                            If you pass null (or omit), a unique label is generated.
- * @return string             The label that was used.  (Use the same label in stop_metrics() if you want.)
- */
-function start_metrics(string $label = null): string
-{
-    global $__metrics_data, $__metrics_stack;
-
-    // 1) If no label provided, generate one
-    if ($label === null) {
-        // uniqid('m_', true) gives something like "m_5cd1e4d3a1f71.12345600"
-        $label = uniqid('m_', true);
-    }
-
-    // 2) Warn if the same label is already running
-    if (isset($__metrics_data[$label])) {
-        trigger_error("start_metrics(): metrics with label '$label' already started.", E_USER_WARNING);
-    }
-
-    // 3) Capture "before" values
-    $t0 = microtime(true);
-    $m0 = memory_get_usage();
-    $p0 = memory_get_peak_usage();
-
-    // 4) Store them under $__metrics_data
-    $__metrics_data[$label] = [
-        'time'   => $t0,
-        'memory' => $m0,
-        'peak'   => $p0,
-    ];
-
-    // 5) Push this label onto the stack (so stop_metrics() with no args can pop it)
-    $__metrics_stack[] = $label;
-
-    return $label;
-}
-
-/**
- * Stop measuring time & memory and compute deltas.
- *
- * @param string|null $label  Optional: the label you used in start_metrics().
- *                            If you pass null, this function will pop the most recently started label.
- * @return array|null         On success, returns an array:
- *                                [
- *                                  'label'       => (string) the label used,
- *                                  'time'        => (float) elapsed seconds,
- *                                  'memory'      => (int)   bytes of memory allocated,
- *                                  'peak_memory' => (int)   extra peak memory (bytes)
- *                                ]
- *                            On failure (no matching start), returns null and emits a warning.
- */
-function stop_metrics(string $label = null): ?array
-{
-    global $__metrics_data, $__metrics_stack;
-
-    // 1) If no label provided, pop the most recent one
-    if ($label === null) {
-        if (empty($__metrics_stack)) {
-            trigger_error("stop_metrics(): no active measurements to stop.", E_USER_WARNING);
-            return null;
-        }
-        $label = array_pop($__metrics_stack);
-    } else {
-        // 2) If a label was provided, remove it from the stack if present
-        $idx = array_search($label, $__metrics_stack, true);
-        if ($idx !== false) {
-            array_splice($__metrics_stack, $idx, 1);
-        }
-    }
-
-    // 3) Check that we had a start for this label
-    if (!isset($__metrics_data[$label])) {
-        trigger_error("stop_metrics(): no metrics found for label '$label'.", E_USER_WARNING);
-        return null;
-    }
-
-    // 4) Grab the "before" values
-    $start = $__metrics_data[$label];
-    unset($__metrics_data[$label]);
-
-    // 5) Capture "after" values
-    $t1 = microtime(true);
-    $m1 = memory_get_usage();
-    $p1 = memory_get_peak_usage();
-
-    // 6) Compute deltas
-    $elapsed   = $t1 - $start['time'];
-    $memDelta  = $m1 - $start['memory'];
-    $peakDelta = $p1 - $start['peak'];
-
-    return [
-        'label'       => $label,
-        'time'        => $elapsed,
-        'memory'      => $memDelta,
-        'peak_memory' => $peakDelta,
-    ];
-}
-
-/**
- * Print a human‐readable summary of the metrics array returned by stop_metrics().
- *
- * @param array|null $metrics
- *     Example of $metrics:
- *       [
- *         'label'       => 'my_func',
- *         'time'        => 0.123456,
- *         'memory'      => 1048576,     // bytes
- *         'peak_memory' => 2097152,     // bytes
- *       ]
- *
- * If $metrics is null or not an array, prints a warning.
- */
-function print_metrics(?array $metrics): void
-{
-    if (!is_array($metrics)) {
-        echo "print_metrics(): no metrics to display.\n";
-        return;
-    }
-
-    $label  = $metrics['label']       ?? '';
-    $time   = $metrics['time']        ?? 0.0;
-    $memory = $metrics['memory']      ?? 0;
-    $peak   = $metrics['peak_memory'] ?? 0;
-
-    if ($label !== '') {
-        echo "Metrics for '{$label}':\n";
-    } else {
-        echo "Metrics:\n";
-    }
-    echo "- Elapsed time:         " . round($time, 6)   . " seconds\n";
-    echo "- Memory used:          " . number_format($memory)  . " bytes\n";
-    echo "- Peak memory increase: " . number_format($peak)    . " bytes\n";
-}
 
 /**
  *  @author camlafit <https://github.com/camlafit>
@@ -411,56 +267,31 @@ $csv = fopen('php://output', 'w');
 if (!$limit || (false !== $offset && 0 === (int) $offset)) {
     fputcsv($csv, $header, DfTools::TXT_SEPARATOR);
 }
-$startLabel = start_metrics("full");
-if (isset($_GET["old"]) && $_GET["old"] == 1) {
 
-    // PRODUCTS
-    $rows = DfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
-
-    $rows = arrayMergeByIdProduct($rows, $extraRows);
-
-    // In case there is no need to display prices, avoid calculating the mins by variant
-    $minPriceVariantByProductId = ($shouldShowProductVariations && $shouldDisplayPrices) ? DfTools::getMinVariantPrices($rows, $shouldPricesUseTaxes, $currencies, $lang->id, $shop->id) : [];
-
-
-    foreach ($rows as $row) {
-        $product = $dfProductBuild->buildProduct($row, $minPriceVariantByProductId, $additionalAttributesHeaders, $additionalHeaders);
-        $product = $dfProductBuild->applySpecificTransformationsForCsv($product, $extraHeader, $header);
-        fputcsv($csv, $product, DfTools::TXT_SEPARATOR);
-    }
-} else {
-
-
-
-    $products = DfTools::getAvailableProductsForLanguageV2($lang->id, $shouldShowProductVariations, $limit, $offset);
-    $empty_line = array_fill_keys($header, null);
-    foreach ($products as $product) {
-        $minProductPrices = [];
-        if ($shouldShowProductVariations && $product['variant_count'] > 0) {
-            $variations = DfTools::getProductVariationsV2($product['id_product']);
-            foreach ($variations as $variation) {
-                if ($shouldDisplayPrices) {
-                    $variantPrices = DfTools::getVariantPrices($variation['id_product'], $variation['id_product_attribute'], $shouldPricesUseTaxes, $currencies);
-                    if (!isset($minProductPrices['onsale_price']) || $variantPrices['onsale_price'] < $minProductPrices['onsale_price']) {
-                        $minProductPrices = $variantPrices;
-                    }
+$products = DfTools::getAvailableProducts($lang->id, $shouldShowProductVariations, $limit, $offset);
+$empty_line = array_fill_keys($header, null);
+foreach ($products as $product) {
+    $minProductPrices = [];
+    if ($shouldShowProductVariations && $product['variant_count'] > 0) {
+        $variations = DfTools::getProductVariations($product['id_product']);
+        foreach ($variations as $variation) {
+            if ($shouldDisplayPrices) {
+                $variantPrices = DfTools::getVariantPrices($variation['id_product'], $variation['id_product_attribute'], $shouldPricesUseTaxes, $currencies);
+                if (!isset($minProductPrices['onsale_price']) || $variantPrices['onsale_price'] < $minProductPrices['onsale_price']) {
+                    $minProductPrices = $variantPrices;
                 }
-                $expanded_variation = array_merge($product, $variation);
-                $built_variation = $dfProductBuild->buildProduct($expanded_variation, [], $additionalAttributesHeaders, $additionalHeaders);
-                $csv_product = $dfProductBuild->applySpecificTransformationsForCsv($built_variation, $extraHeader, $header);
-                fputcsv($csv, $csv_product, DfTools::TXT_SEPARATOR);
             }
-            $product = $dfProductBuild->buildProduct($product, [$product['id_product'] => $minProductPrices], $additionalAttributesHeaders, $additionalHeaders);
-        } else {
-            $product = $dfProductBuild->buildProduct($product, [], $additionalAttributesHeaders, $additionalHeaders);
+            $expanded_variation = array_merge($product, $variation);
+            $built_variation = $dfProductBuild->buildProduct($expanded_variation, [], $additionalAttributesHeaders, $additionalHeaders);
+            $csv_product = $dfProductBuild->applySpecificTransformationsForCsv($built_variation, $extraHeader, $header);
+            fputcsv($csv, $csv_product, DfTools::TXT_SEPARATOR);
         }
-
-        $product = $dfProductBuild->applySpecificTransformationsForCsv($product, $extraHeader, $header);
-        fputcsv($csv, $product, DfTools::TXT_SEPARATOR);
+        $product = $dfProductBuild->buildProduct($product, [$product['id_product'] => $minProductPrices], $additionalAttributesHeaders, $additionalHeaders);
+    } else {
+        $product = $dfProductBuild->buildProduct($product, [], $additionalAttributesHeaders, $additionalHeaders);
     }
-}
-$metrics = stop_metrics("full");
-if ($_GET["metrics"] == 1) {
-    print_metrics($metrics);
+
+    $product = $dfProductBuild->applySpecificTransformationsForCsv($product, $extraHeader, $header);
+    fputcsv($csv, $product, DfTools::TXT_SEPARATOR);
 }
 fclose($csv);

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -269,7 +269,6 @@ if (!$limit || (false !== $offset && 0 === (int) $offset)) {
 }
 
 $products = DfTools::getAvailableProducts($lang->id, $shouldShowProductVariations, $limit, $offset);
-$emptyLine = array_fill_keys($header, null);
 foreach ($products as $product) {
     $minProductPrices = [];
     if ($shouldShowProductVariations && $product['variant_count'] > 0) {

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -269,7 +269,7 @@ if (!$limit || (false !== $offset && 0 === (int) $offset)) {
 }
 
 $products = DfTools::getAvailableProducts($lang->id, $shouldShowProductVariations, $limit, $offset);
-$empty_line = array_fill_keys($header, null);
+$emptyLine = array_fill_keys($header, null);
 foreach ($products as $product) {
     $minProductPrices = [];
     if ($shouldShowProductVariations && $product['variant_count'] > 0) {

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -437,7 +437,7 @@ if(isset($_GET["old"]) && $_GET["old"] == 1) {
     foreach ($products as $product) {
         $minProductPrices = [];
         if ($shouldShowProductVariations && $product['variant_count'] > 0) {
-            $variations = DfTools::getProductVariationsV2($product['id_product'], $lang->id);
+            $variations = DfTools::getProductVariationsV2($product['id_product']);
             foreach ($variations as $variation) {
                 if ($shouldDisplayPrices) {
                     $variantPrices = DfTools::getVariantPrices($variation['id_product'], $variation['id_product_attribute'], $shouldPricesUseTaxes, $currencies);

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -460,7 +460,7 @@ if (isset($_GET["old"]) && $_GET["old"] == 1) {
     }
 }
 $metrics = stop_metrics("full");
-if ($_GET["debug"] == 1) {
+if ($_GET["metrics"] == 1) {
     print_metrics($metrics);
 }
 fclose($csv);

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -412,7 +412,7 @@ if (!$limit || (false !== $offset && 0 === (int) $offset)) {
     fputcsv($csv, $header, DfTools::TXT_SEPARATOR);
 }
 $startLabel = start_metrics("full");
-if(isset($_GET["old"]) && $_GET["old"] == 1) {
+if (isset($_GET["old"]) && $_GET["old"] == 1) {
 
     // PRODUCTS
     $rows = DfTools::getAvailableProductsForLanguage($lang->id, $shop->id, $limit, $offset);
@@ -460,7 +460,7 @@ if(isset($_GET["old"]) && $_GET["old"] == 1) {
     }
 }
 $metrics = stop_metrics("full");
-if ($_GET["debug"] ==1 ) {
-print_metrics($metrics);
+if ($_GET["debug"] == 1) {
+    print_metrics($metrics);
 }
 fclose($csv);

--- a/src/Entity/DfProductBuild.php
+++ b/src/Entity/DfProductBuild.php
@@ -274,11 +274,11 @@ class DfProductBuild
         }
 
         if ($this->productVariations) {
-            $p['variation_reference'] = $product['variation_reference'];
-            $p['variation_supplier_reference'] = $product['variation_supplier_reference'];
-            $p['variation_mpn'] = $product['variation_mpn'];
-            $p['variation_ean13'] = $product['variation_ean13'];
-            $p['variation_upc'] = $product['variation_upc'];
+            $p['variation_reference'] = DfTools::cleanString($product['variation_reference']);
+            $p['variation_supplier_reference'] = DfTools::cleanString($product['variation_supplier_reference']);
+            $p['variation_mpn'] = DfTools::cleanString($product['variation_mpn']);
+            $p['variation_ean13'] = DfTools::cleanString($product['variation_ean13']);
+            $p['variation_upc'] = DfTools::cleanString($product['variation_upc']);
             $p['df_group_leader'] = (is_numeric($product['df_group_leader']) && 0 !== (int) $product['df_group_leader']);
             $p['df_variants_information'] = $this->getVariantsInformation($product);
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -619,10 +619,11 @@ class DfTools
         $imsCoverField = self::versionGte('1.5.1.0') ? 'ims.cover = 1' : 'im.cover = 1';
 
         $query->select('MIN(ims.id_image) AS id_image');
+        $query->leftJoin('image', 'im', 'im.id_product = p.id_product');
         $query->leftJoin(
             'image_shop',
             'ims',
-            'ims.id_product = product_shop.id_product
+            'im.id_image = ims.id_image
             AND ims.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')
             AND ' . $imsCoverField
         );
@@ -675,12 +676,12 @@ class DfTools
         $query->leftJoin(
             'product_tag',
             'pt',
-            'pt.id_product = product_shop.id_product AND pt.id_lang = ' . (int) $idLang
+            'pt.id_product = product_shop.id_product'
         );
         $query->leftJoin(
             'tag',
             'tag',
-            'pt.`id_tag` = tag.`id_tag`'
+            'pt.`id_tag` = tag.`id_tag` AND tag.`id_lang` = ' . (int) $idLang
         );
 
         $query->select('GROUP_CONCAT(cl.id_category ORDER BY cl.id_category) AS category_ids');
@@ -890,7 +891,7 @@ class DfTools
         LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
           ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
         LEFT JOIN (_DB_PREFIX_tag tag
-            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND tag.id_lang = _ID_LANG_)
           ON (pt.id_product = p.id_product)
         LEFT JOIN _DB_PREFIX_stock_available sa
           ON (p.id_product = sa.id_product AND sa.id_product_attribute = 0
@@ -960,7 +961,7 @@ class DfTools
                 LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
                 ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
                 LEFT JOIN (_DB_PREFIX_tag tag
-                    INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+                    INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND tag.id_lang = _ID_LANG_)
                 ON (pt.id_product = p.id_product)
                 LEFT JOIN _DB_PREFIX_stock_available sa
                 ON (p.id_product = sa.id_product AND sa.id_product_attribute = 0
@@ -1078,7 +1079,7 @@ class DfTools
         LEFT JOIN _DB_PREFIX_product_attribute_image pa_im
           ON (pa_im.id_product_attribute = pa.id_product_attribute)
         LEFT JOIN (_DB_PREFIX_tag tag
-            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND tag.id_lang = _ID_LANG_)
           ON (pt.id_product = p.id_product)
         LEFT JOIN _DB_PREFIX_stock_available sa
           ON (p.id_product = sa.id_product

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -542,7 +542,7 @@ class DfTools
             false
         );
         $link = $instance->connect();
-        if ( 'DbPDO' === $class && method_exists($link, 'setAttribute')) {
+        if ('DbPDO' === $class && method_exists($link, 'setAttribute')) {
             // Set the PDO attribute to not use buffered queries
             // This is needed to avoid memory issues with large datasets
 
@@ -551,7 +551,7 @@ class DfTools
         return $instance;
     }
 
-     /**
+    /**
      * Loads configuration settings for slave servers if needed.
      */
     protected static function loadSlaveServers()
@@ -619,7 +619,9 @@ class DfTools
         $imsCoverField = self::versionGte('1.5.1.0') ? 'ims.cover = 1' : 'im.cover = 1';
 
         $query->select('ANY_VALUE(ims.id_image) AS id_image');
-        $query->leftJoin('image_shop', 'ims',
+        $query->leftJoin(
+            'image_shop',
+            'ims',
             'ims.id_product = product_shop.id_product
             AND ims.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')
             AND ' . $imsCoverField
@@ -751,7 +753,8 @@ class DfTools
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
-    public static function getProductVariationsV2($idProduct) {
+    public static function getProductVariationsV2($idProduct)
+    {
         $query = new \DbQuery();
 
         $query->select('pa.reference AS variation_reference, pa.ean13 AS variation_ean13, pa.upc AS variation_upc');
@@ -776,13 +779,18 @@ class DfTools
         $query->join(\Shop::addSqlAssociation('product_attribute', 'pa'));
         $query->where('product_attribute_shop.id_product = ' . (int) $idProduct);
 
-        $query->leftJoin('product', 'p',
+        $query->leftJoin(
+            'product',
+            'p',
             'p.id_product = product_attribute_shop.id_product'
         );
 
         $query->select('pa_im.id_image AS variation_image_id');
-        $query->leftJoin('product_attribute_image', 'pa_im',
-            'pa_im.id_product_attribute = product_attribute_shop.id_product_attribute');
+        $query->leftJoin(
+            'product_attribute_image',
+            'pa_im',
+            'pa_im.id_product_attribute = product_attribute_shop.id_product_attribute'
+        );
 
         // Product supplier reference
         $query->select('psp.product_supplier_reference AS variation_supplier_reference');

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1821,7 +1821,7 @@ class DfTools
                     'price' => $variantPrice,
                     'onsale_price' => $variantOnsalePrice,
                     'multiprice' => $variantMultiprice,
-                    'id_product_attribute' => self::getVariantUrl($product, $context),
+                    'link' => self::getVariantUrl($product, $context),
                 ];
             }
         }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -751,7 +751,7 @@ class DfTools
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
-    public static function getProductVariationsV2($idProduct, $idLang) {
+    public static function getProductVariationsV2($idProduct) {
         $query = new \DbQuery();
 
         $query->select('pa.reference AS variation_reference, pa.ean13 AS variation_ean13, pa.upc AS variation_upc');

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -702,7 +702,7 @@ class DfTools
 
         $query->select('IFNULL(vc.count, 0) as variant_count');
         if ($checkLeadership) {
-            $query->select('IF(ISNULL(vc.count) OR vc.count > 0,true, false) as df_group_leader');
+            $query->select('IF(NOT ISNULL(vc.count) AND vc.count > 0,true, false) as df_group_leader');
         } else {
             $query->select('true as df_group_leader');
         }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -588,7 +588,7 @@ class DfTools
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null Array of products with their associated information
      */
-    public static function getAvailableProductsForLanguageV2($idLang, $checkLeadership=true, $limit = false, $offset = false, $ids = null)
+    public static function getAvailableProducts($idLang, $checkLeadership=true, $limit = false, $offset = false, $ids = null)
     {
 
         $query = new \DbQuery();
@@ -739,9 +739,7 @@ class DfTools
         if ($limit) {
             $query->limit((int) $limit, (int) $offset);
         }
-        // echo "<pre>";
-        // var_dump($query->__toString());
-        // echo "</pre>";
+
         return self::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 
@@ -753,7 +751,7 @@ class DfTools
      *
      * @return array|false|mysqli_result|PDOStatement|resource|null
      */
-    public static function getProductVariationsV2($idProduct)
+    public static function getProductVariations($idProduct)
     {
         $query = new \DbQuery();
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -568,6 +568,26 @@ class DfTools
         self::$_slave_servers_loaded = true;
     }
 
+    /**
+     * Retrieve available products information for a specific language.
+     *
+     * This method fetches products with their associated data including:
+     * - Basic product information (reference, EAN13, UPC, ISBN, etc.)
+     * - Product descriptions and meta information
+     * - Stock information
+     * - Category information
+     * - Manufacturer details
+     * - Product tags
+     * - Variation information
+     *
+     * @param int $idLang Language ID to retrieve product information in
+     * @param bool $checkLeadership Whether to check if product is a variant group leader (true by default)
+     * @param int|bool $limit Maximum number of products to retrieve (false for no limit)
+     * @param int|bool $offset Offset for pagination (false for no offset)
+     * @param array|null $ids Specific product IDs to retrieve (not implemented in current code)
+     *
+     * @return array|false|mysqli_result|PDOStatement|resource|null Array of products with their associated information
+     */
     public static function getAvailableProductsForLanguageV2($idLang, $checkLeadership=true, $limit = false, $offset = false, $ids = null)
     {
 
@@ -723,6 +743,14 @@ class DfTools
         return self::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 
+    /**
+     * Returns the product variations for a product
+     *
+     * @param int $idProduct ID of the product
+     * @param int $idLang language ID
+     *
+     * @return array|false|mysqli_result|PDOStatement|resource|null
+     */
     public static function getProductVariationsV2($idProduct, $idLang) {
         $query = new \DbQuery();
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1203,7 +1203,7 @@ class DfTools
             if (!\Validate::isLoadedObject($category)) {
                 continue;
             }
-            if ( (bool)\Configuration::get('PS_REWRITING_SETTINGS') ) {
+            if ((bool)\Configuration::get('PS_REWRITING_SETTINGS')) {
                 $categoryLink = $link->getCategoryLink($category);
                 $urls[] = trim(parse_url($categoryLink, PHP_URL_PATH), '/');
             } else {

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -773,23 +773,24 @@ class DfTools
             $query->select('pa.reference AS variation_mpn');
         }
 
+        // Product attribute table fields
+        $query->select('pa.id_product, pa.id_product_attribute');
         $query->from('product_attribute', 'pa');
         // Product shop table fields
-        $query->select('product_attribute_shop.id_product, product_attribute_shop.id_product_attribute');
         $query->join(\Shop::addSqlAssociation('product_attribute', 'pa'));
-        $query->where('product_attribute_shop.id_product = ' . (int) $idProduct);
+        $query->where('pa.id_product = ' . (int) $idProduct);
 
         $query->leftJoin(
             'product',
             'p',
-            'p.id_product = product_attribute_shop.id_product'
+            'p.id_product = pa.id_product'
         );
 
         $query->select('pa_im.id_image AS variation_image_id');
         $query->leftJoin(
             'product_attribute_image',
             'pa_im',
-            'pa_im.id_product_attribute = product_attribute_shop.id_product_attribute'
+            'pa_im.id_product_attribute = pa.id_product_attribute'
         );
 
         // Product supplier reference
@@ -798,7 +799,7 @@ class DfTools
             'product_supplier',
             'psp',
             'p.`id_product` = psp.`id_product`
-            AND psp.`id_product_attribute` = product_attribute_shop.id_product_attribute'
+            AND psp.`id_product_attribute` = pa.id_product_attribute'
         );
 
         $query->select('sa.out_of_stock as out_of_stock, sa.quantity as stock_quantity');
@@ -806,12 +807,12 @@ class DfTools
             'stock_available',
             'sa',
             'p.id_product = sa.id_product
-            AND sa.id_product_attribute = product_attribute_shop.id_product_attribute
+            AND sa.id_product_attribute = pa.id_product_attribute
             AND (sa.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')
             OR (sa.id_shop = 0 AND sa.id_shop_group = ' . (int) \Shop::getContextShopGroupID() . '))'
         );
 
-        $query->groupBy('product_attribute_shop.id_product, product_attribute_shop.id_product_attribute');
+        $query->groupBy('pa.id_product_attribute');
 
         return self::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -684,7 +684,7 @@ class DfTools
             'pt.`id_tag` = tag.`id_tag` AND tag.`id_lang` = ' . (int) $idLang
         );
 
-        $query->select('GROUP_CONCAT(cl.id_category ORDER BY cl.id_category) AS category_ids');
+        $query->select('GROUP_CONCAT(DISTINCT(cl.id_category) ORDER BY cl.id_category) AS category_ids');
         $query->leftJoin(
             'category_product',
             'cp',
@@ -1202,8 +1202,12 @@ class DfTools
             if (!\Validate::isLoadedObject($category)) {
                 continue;
             }
-            $categoryLink = $link->getCategoryLink($category);
-            $urls[] = trim(parse_url($categoryLink, PHP_URL_PATH), '/');
+            if ( (bool)\Configuration::get('PS_REWRITING_SETTINGS') ) {
+                $categoryLink = $link->getCategoryLink($category);
+                $urls[] = trim(parse_url($categoryLink, PHP_URL_PATH), '/');
+            } else {
+                $urls[] = $category_id;
+            }
         }
         return $urls;
     }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -786,8 +786,6 @@ class DfTools
 
         // Product supplier reference
         $query->select('psp.product_supplier_reference AS variation_supplier_reference');
-        // Product supplier reference
-        $query->select('psp.product_supplier_reference AS supplier_reference');
         $query->leftJoin(
             'product_supplier',
             'psp',

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -618,7 +618,7 @@ class DfTools
         // Product image table fields
         $imsCoverField = self::versionGte('1.5.1.0') ? 'ims.cover = 1' : 'im.cover = 1';
 
-        $query->select('ANY_VALUE(ims.id_image) AS id_image');
+        $query->select('MIN(ims.id_image) AS id_image');
         $query->leftJoin(
             'image_shop',
             'ims',
@@ -637,7 +637,7 @@ class DfTools
             AND psp.`id_product_attribute` = 0'
         );
 
-        $query->select('ANY_VALUE(sa.out_of_stock) as out_of_stock, ANY_VALUE(sa.quantity) as stock_quantity');
+        $query->select('MIN(sa.out_of_stock) as out_of_stock, MIN(sa.quantity) as stock_quantity');
         $query->leftJoin(
             'stock_available',
             'sa',

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -704,7 +704,7 @@ class DfTools
         if ($checkLeadership) {
             $query->select('IF(NOT ISNULL(vc.count) AND vc.count > 0,true, false) as df_group_leader');
         } else {
-            $query->select('true as df_group_leader');
+            $query->select('false as df_group_leader');
         }
 
         $query->join('LEFT JOIN (

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -628,6 +628,7 @@ class DfTools
         );
 
         // Product supplier reference
+        // See: [PR#181](https://github.com/doofinder/doofinder-prestashop/pull/181)
         $query->select('COALESCE(psp.product_supplier_reference, p.supplier_reference) as supplier_reference, psp.product_supplier_reference AS variation_supplier_reference');
         $query->leftJoin(
             'product_supplier',

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -833,13 +833,13 @@ class DfTools
     {
         $Shop = new \Shop($idShop);
 
-        $showVariations = (bool) self::cfg($idShop, 'DF_SHOW_PRODUCT_VARIATIONS');
+
 
         $isbn = '';
         $isbnPa = '';
         if (self::versionGte('1.7.0.0')) {
             $isbn = 'p.isbn,';
-            if ($showVariations) {
+            if (self::cfg($idShop, 'DF_SHOW_PRODUCT_VARIATIONS') == 1) {
                 $isbnPa = 'IF(isnull(pa.id_product), p.isbn , pa.isbn) AS isbn,';
             }
         }
@@ -848,16 +848,149 @@ class DfTools
         $mpnPa = 'pa.reference AS variation_mpn,';
         if (self::versionGte('1.7.7.0')) {
             $mpn = 'p.mpn AS mpn,';
-            if ($showVariations) {
+            if (self::cfg($idShop, 'DF_SHOW_PRODUCT_VARIATIONS') == 1) {
                 $mpnPa = 'pa.mpn AS variation_mpn,';
             }
+        }
+
+        $sql = '
+      SELECT
+        ps.id_product,
+        ps.show_price,
+        cl.name as main_category,
+        __ID_CATEGORY_DEFAULT_FIELD__,
+        m.name AS manufacturer,
+        ' . $mpn . '
+        p.ean13 AS ean13,
+        ' . $isbn . "
+        p.upc,
+        p.reference,
+        psp.product_supplier_reference AS supplier_reference,
+        pl.name,
+        pl.description,
+        pl.description_short,
+        pl.meta_title,
+        pl.meta_description,
+        GROUP_CONCAT(tag.name ORDER BY tag.name) AS tags,
+        pl.link_rewrite,
+        cl.link_rewrite AS cat_link_rew,
+        im.id_image,
+        ps.available_for_order,
+        sa.out_of_stock,
+        sa.quantity as stock_quantity
+      FROM
+        _DB_PREFIX_product p
+        INNER JOIN _DB_PREFIX_product_shop ps
+          ON (p.id_product = ps.id_product AND ps.id_shop = _ID_SHOP_)
+        LEFT JOIN _DB_PREFIX_product_lang pl
+          ON (p.id_product = pl.id_product AND pl.id_shop = _ID_SHOP_ AND pl.id_lang = _ID_LANG_)
+        LEFT JOIN _DB_PREFIX_manufacturer m
+          ON (p.id_manufacturer = m.id_manufacturer)
+        LEFT JOIN _DB_PREFIX_category_lang cl
+          ON (__ID_CATEGORY_DEFAULT_FIELD__ = cl.id_category AND cl.id_shop = _ID_SHOP_ AND cl.id_lang = _ID_LANG_)
+        LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
+          ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
+        LEFT JOIN (_DB_PREFIX_tag tag
+            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+          ON (pt.id_product = p.id_product)
+        LEFT JOIN _DB_PREFIX_stock_available sa
+          ON (p.id_product = sa.id_product AND sa.id_product_attribute = 0
+            AND (sa.id_shop = _ID_SHOP_ OR
+            (sa.id_shop = 0 AND sa.id_shop_group = _ID_SHOPGROUP_)))
+        LEFT JOIN _DB_PREFIX_product_supplier psp
+          ON (p.id_product = psp.id_product AND psp.id_product_attribute = 0)
+      WHERE
+        __IS_ACTIVE__
+        __VISIBILITY__
+        __PRODUCT_IDS__
+      GROUP BY
+        p.id_product
+      ORDER BY
+        p.id_product
+    ";
+
+        $sqlVariations = self::getSQLForVariants($mpnPa, $mpn, $isbnPa);
+
+        if ($includeParents) {
+            $sqlVariations .= "
+            UNION
+            SELECT
+                ps.id_product,
+                (SELECT COUNT(*) FROM _DB_PREFIX_product prod LEFT OUTER JOIN _DB_PREFIX_product_attribute pa
+                ON (prod.id_product = pa.id_product) WHERE prod.id_product = p.id_product) AS variant_count,
+                ps.show_price,
+                0,
+                null AS variation_reference,
+                psp.product_supplier_reference AS variation_supplier_reference,
+                null AS variation_mpn,
+                null AS variation_ean13,
+                null AS variation_upc,
+                null AS variation_image_id,
+                cl.name as main_category,
+                __ID_CATEGORY_DEFAULT_FIELD__ as id_category_default,
+                m.name AS manufacturer,
+                $mpn
+                p.ean13 AS ean13,
+                $isbn
+                p.upc,
+                p.reference,
+                p.supplier_reference,
+                IF(ISNULL(pan.attribute_n), true, false) AS df_group_leader,
+                pl.name,
+                pl.description,
+                pl.description_short,
+                pl.meta_title,
+                pl.meta_description,
+                GROUP_CONCAT(tag.name ORDER BY tag.name) AS tags,
+                pl.link_rewrite,
+                cl.link_rewrite AS cat_link_rew,
+                im.id_image,
+                ps.available_for_order,
+                sa.out_of_stock,
+                sa.quantity as stock_quantity
+            FROM
+                _DB_PREFIX_product p
+                INNER JOIN _DB_PREFIX_product_shop ps
+                ON (p.id_product = ps.id_product AND ps.id_shop = _ID_SHOP_)
+                LEFT JOIN _DB_PREFIX_product_lang pl
+                ON (p.id_product = pl.id_product AND pl.id_shop = _ID_SHOP_ AND pl.id_lang = _ID_LANG_)
+                LEFT JOIN _DB_PREFIX_manufacturer m
+                ON (p.id_manufacturer = m.id_manufacturer)
+                LEFT JOIN _DB_PREFIX_category_lang cl
+                ON (__ID_CATEGORY_DEFAULT_FIELD__ = cl.id_category AND cl.id_shop = _ID_SHOP_ AND cl.id_lang = _ID_LANG_)
+                LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
+                ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
+                LEFT JOIN (_DB_PREFIX_tag tag
+                    INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+                ON (pt.id_product = p.id_product)
+                LEFT JOIN _DB_PREFIX_stock_available sa
+                ON (p.id_product = sa.id_product AND sa.id_product_attribute = 0
+                    AND (sa.id_shop = _ID_SHOP_ OR
+                    (sa.id_shop = 0 AND sa.id_shop_group = _ID_SHOPGROUP_)))
+                LEFT JOIN _DB_PREFIX_product_supplier psp
+                ON (p.id_product = psp.id_product AND psp.id_product_attribute = 0)
+                LEFT JOIN (SELECT id_product, COUNT(*) as attribute_n FROM _DB_PREFIX_product_attribute GROUP BY id_product) pan
+                    ON p.id_product = pan.id_product
+            WHERE
+                __IS_ACTIVE__
+                __VISIBILITY__
+                __PRODUCT_IDS__
+            GROUP BY
+                p.id_product
+            ORDER BY
+                id_product
+            ";
+        }
+
+        if (self::cfg($idShop, 'DF_SHOW_PRODUCT_VARIATIONS') == 1) {
+            $sql = $sqlVariations;
         }
 
         // MIN: 1.5.0.9
         $idCategoryDefault = self::versionGte('1.5.0.9') ? 'ps.id_category_default' : 'p.id_category_default';
         // MIN: 1.5.1.0
         $imsCover = self::versionGte('1.5.1.0') ? 'ims.cover = 1' : 'im.cover = 1';
-        $isActive = self::versionGte('1.5.1.0') ? 'AND ps.active = 1' : 'AND p.active = 1';
+        $isActive = self::versionGte('1.5.1.0') ? 'ps.active = 1' : 'p.active = 1';
 
         if (self::versionGte('1.5.1.0')) {
             $visibility = "AND ps.visibility IN ('search', 'both')";
@@ -868,227 +1001,97 @@ class DfTools
         }
 
         if (is_array($ids) && count($ids)) {
-            $productIds = 'AND ps.id_product IN (' . implode(',', $ids) . ')';
+            $productIds = 'AND p.id_product IN (' . implode(',', $ids) . ')';
         } else {
             $productIds = '';
         }
 
-        $limitSql = '';
-        if (false !== $limit && is_numeric($limit)) {
-            $limitSql .= ' LIMIT ' . (int) $limit;
-
-            if (false !== $offset && is_numeric($offset)) {
-                $limitSql .= ' OFFSET ' . (int) $offset;
-            }
-        }
-
-        // cp.id_category > 2: Ignoring root categories
-        $productsQuery = '
-        SELECT dp.*, dps.tags, dps.category_ids FROM
-        (
-            ' . ($showVariations ? self::getSQLForVariants($mpnPa, $mpn, $isbnPa) . ' UNION ' : '') . '
-            ' . self::getSQLForProducts($showVariations, $mpn, $isbn) . '
-        ) dp
-        INNER JOIN (' . self::getSQLProductShopIds() . ') dps
-            ON dps.id_product = dp.id_product
-        ';
-
-        $productsQuery = self::prepareSQL($productsQuery, [
+        $sql = self::limitSQL($sql, $limit, $offset);
+        $sql = self::prepareSQL($sql, [
             '_ID_LANG_' => (int) pSQL($idLang),
             '_ID_SHOP_' => (int) pSQL($idShop),
             '_ID_SHOPGROUP_' => (int) pSQL($Shop->id_shop_group),
             '_IMS_COVER_' => (string) pSQL($imsCover),
-            '_ID_CATEGORY_DEFAULT_FIELD_' => (string) pSQL($idCategoryDefault),
-            '_IS_ACTIVE_' => (string) pSQL($isActive),
-            '_VISIBILITY_' => (string) pSQL($visibility),
-            '_PRODUCT_IDS_' => (string) pSQL($productIds),
-            '_LIMIT_' => (string) pSQL($limitSql),
+            '__ID_CATEGORY_DEFAULT_FIELD__' => (string) pSQL($idCategoryDefault),
+            '__IS_ACTIVE__' => (string) pSQL($isActive),
+            '__VISIBILITY__' => (string) pSQL($visibility),
+            '__PRODUCT_IDS__' => (string) pSQL($productIds),
         ]);
 
-        $productsQuery = str_replace("\'", "'", $productsQuery);
+        $sql = str_replace("\'", "'", $sql);
 
-        return \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($productsQuery);
-    }
-
-    private static function getSQLProductShopIds()
-    {
-        return '
-        SELECT
-            ps.id_product,
-            GROUP_CONCAT(
-                tag.name
-                ORDER BY
-                tag.name
-            ) AS tags,
-            GROUP_CONCAT(
-                cl.id_category
-                ORDER BY
-                cl.id_category
-            ) AS category_ids
-             FROM
-            _DB_PREFIX_product_shop ps
-            LEFT JOIN _DB_PREFIX_category_product cp ON (cp.id_product = ps.id_product)
-            LEFT JOIN _DB_PREFIX_category_lang cl ON (
-                cl.id_category = cp.id_category
-                AND cl.id_shop = _ID_SHOP_
-                AND cl.id_lang = _ID_LANG_
-                AND cp.id_category > 2
-            )
-            LEFT JOIN _DB_PREFIX_product_tag pt ON (pt.id_product = ps.id_product)
-            LEFT JOIN _DB_PREFIX_tag tag ON (
-                tag.id_tag = pt.id_tag
-                AND tag.id_lang = _ID_LANG_
-            )
-            WHERE
-            ps.id_shop = _ID_SHOP_
-            _IS_ACTIVE_
-            _VISIBILITY_
-            _PRODUCT_IDS_
-            GROUP BY
-            ps.id_product
-            ORDER BY
-            ps.id_product
-            _LIMIT_
-        ';
-    }
-
-    private static function getSQLForProducts($showVariations, $mpn, $isbn)
-    {
-        return "
-        SELECT
-            ps.id_product,
-            COALESCE(vc.count,0) as variant_count,
-            ps.show_price,
-            0 AS product_attribute,
-            null AS variation_reference,
-            null AS variation_supplier_reference,
-            null AS variation_mpn,
-            null AS variation_ean13,
-            null AS variation_upc,
-            null AS variation_image_id,
-            cl.name as main_category,
-            _ID_CATEGORY_DEFAULT_FIELD_ as id_category_default,
-            m.name AS manufacturer,
-            $mpn
-            p.ean13 AS ean13,
-            $isbn
-            p.upc,
-            p.reference,
-            psp.product_supplier_reference AS supplier_reference,
-            " . ($showVariations ? 'IF(ISNULL(vc.count) OR vc.count > 0,true, false)' : 'true') . ' AS df_group_leader,
-            pl.name,
-            pl.description,
-            pl.description_short,
-            pl.meta_title,
-            pl.meta_description,
-            pl.link_rewrite,
-            cl.link_rewrite AS cat_link_rew,
-            ims.id_image,
-            ps.available_for_order,
-            sa.out_of_stock,
-            sa.quantity as stock_quantity
-        FROM
-            _DB_PREFIX_product_shop ps
-            INNER JOIN _DB_PREFIX_product p
-            ON (p.id_product = ps.id_product)
-            LEFT JOIN _DB_PREFIX_product_lang pl
-            ON (pl.id_product = ps.id_product AND pl.id_shop = _ID_SHOP_ AND pl.id_lang = _ID_LANG_)
-            LEFT JOIN _DB_PREFIX_manufacturer m
-            ON (m.id_manufacturer = p.id_manufacturer)
-            LEFT JOIN _DB_PREFIX_category_lang cl
-            ON (_ID_CATEGORY_DEFAULT_FIELD_ = cl.id_category AND cl.id_shop = _ID_SHOP_ AND cl.id_lang = _ID_LANG_)
-            LEFT JOIN _DB_PREFIX_image_shop ims
-                    ON
-                (ims.id_product = ps.id_product
-                    AND ims.id_shop = _ID_SHOP_
-                    AND _IMS_COVER_)
-            LEFT JOIN _DB_PREFIX_image_lang iml
-                        ON
-                (ims.id_image = iml.id_image AND iml.id_lang = _ID_LANG_)
-            LEFT JOIN _DB_PREFIX_stock_available sa
-            ON (p.id_product = sa.id_product AND sa.id_product_attribute = 0
-                AND (sa.id_shop = _ID_SHOP_ OR
-                (sa.id_shop = 0 AND sa.id_shop_group = _ID_SHOPGROUP_)))
-            LEFT JOIN _DB_PREFIX_product_supplier psp
-            ON (p.id_supplier = psp.id_supplier AND p.id_product = psp.id_product AND psp.id_product_attribute = 0)
-            LEFT JOIN (
-                SELECT
-                    id_product,
-                    count(*) as count
-                FROM
-                    _DB_PREFIX_product_attribute pas
-                GROUP BY
-                    id_product
-            ) vc ON
-            vc.id_product = ps.id_product
-            WHERE ps.id_shop = _ID_SHOP_
-    ';
+        return \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
     }
 
     private static function getSQLForVariants($mpnPa, $mpn, $isbnPa)
     {
-        return "
-        SELECT
-            ps.id_product,
-            0 AS variant_count,
-            ps.show_price,
-            pa.id_product_attribute,
-            pa.reference AS variation_reference,
-            psp.product_supplier_reference AS variation_supplier_reference,
-            $mpnPa
-            pa.ean13 AS variation_ean13,
-            pa.upc AS variation_upc,
-            pa_im.id_image AS variation_image_id,
-            cl.name as main_category,
-            _ID_CATEGORY_DEFAULT_FIELD_,
-            m.name AS manufacturer,
-            $mpn
-            p.ean13 AS ean13,
-            $isbnPa
-            p.upc AS upc,
-            p.reference AS reference,
-            p.supplier_reference AS supplier_reference,
-            0 AS df_group_leader,
-            pl.name,
-            pl.description,
-            pl.description_short,
-            pl.meta_title,
-            pl.meta_description,
-            pl.link_rewrite,
-            cl.link_rewrite AS cat_link_rew,
-            im.id_image,
-            ps.available_for_order,
-            sa.out_of_stock,
-            sa.quantity as stock_quantity
-        FROM
-            _DB_PREFIX_product_shop ps
-            INNER JOIN _DB_PREFIX_product p
-            ON (p.id_product = ps.id_product)
-            LEFT JOIN _DB_PREFIX_product_lang pl
-            ON (p.id_product = pl.id_product AND pl.id_shop = _ID_SHOP_ AND pl.id_lang = _ID_LANG_)
-            LEFT JOIN _DB_PREFIX_manufacturer m
-            ON (p.id_manufacturer = m.id_manufacturer)
-            LEFT JOIN _DB_PREFIX_category_lang cl
-            ON (_ID_CATEGORY_DEFAULT_FIELD_ = cl.id_category AND cl.id_shop = _ID_SHOP_ AND cl.id_lang = _ID_LANG_)
-            LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
-            ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
-            LEFT OUTER JOIN _DB_PREFIX_product_attribute pa
-            ON (p.id_product = pa.id_product)
-            LEFT JOIN _DB_PREFIX_product_supplier psp
-            ON (p.id_supplier = psp.id_supplier AND p.id_product = psp.id_product AND pa.id_product_attribute = psp.id_product_attribute)
-            INNER JOIN _DB_PREFIX_product_attribute_shop pas
-            ON (pas.id_product_attribute = pa.id_product_attribute AND pas.id_shop = _ID_SHOP_)
-            LEFT JOIN _DB_PREFIX_product_attribute_image pa_im
-            ON (pa_im.id_product_attribute = pa.id_product_attribute)
-            LEFT JOIN _DB_PREFIX_stock_available sa
-            ON (p.id_product = sa.id_product
-                AND sa.id_product_attribute = IF(isnull(pa.id_product), 0, pa.id_product_attribute)
-                AND (sa.id_shop = _ID_SHOP_ OR
-                (sa.id_shop = 0 AND sa.id_shop_group = _ID_SHOPGROUP_)))
-        WHERE
-            ps.id_shop = _ID_SHOP_
-            AND pa.id_product_attribute is not null
-        ";
+        return "SELECT
+        ps.id_product,
+        0 AS variant_count,
+        ps.show_price,
+        pa.id_product_attribute,
+        pa.reference AS variation_reference,
+        psp.product_supplier_reference AS variation_supplier_reference,
+        $mpnPa
+        pa.ean13 AS variation_ean13,
+        pa.upc AS variation_upc,
+        pa_im.id_image AS variation_image_id,
+        cl.name as main_category,
+        __ID_CATEGORY_DEFAULT_FIELD__,
+        m.name AS manufacturer,
+        $mpn
+        p.ean13 AS ean13,
+        $isbnPa
+        p.upc AS upc,
+        p.reference AS reference,
+        p.supplier_reference AS supplier_reference,
+        0 AS df_group_leader,
+        pl.name,
+        pl.description,
+        pl.description_short,
+        pl.meta_title,
+        pl.meta_description,
+        GROUP_CONCAT(tag.name ORDER BY tag.name) AS tags,
+        pl.link_rewrite,
+        cl.link_rewrite AS cat_link_rew,
+        im.id_image,
+        ps.available_for_order,
+        sa.out_of_stock,
+        sa.quantity as stock_quantity
+      FROM
+        _DB_PREFIX_product p
+        INNER JOIN _DB_PREFIX_product_shop ps
+          ON (p.id_product = ps.id_product AND ps.id_shop = _ID_SHOP_)
+        LEFT JOIN _DB_PREFIX_product_lang pl
+          ON (p.id_product = pl.id_product AND pl.id_shop = _ID_SHOP_ AND pl.id_lang = _ID_LANG_)
+        LEFT JOIN _DB_PREFIX_manufacturer m
+          ON (p.id_manufacturer = m.id_manufacturer)
+        LEFT JOIN _DB_PREFIX_category_lang cl
+          ON (__ID_CATEGORY_DEFAULT_FIELD__ = cl.id_category AND cl.id_shop = _ID_SHOP_ AND cl.id_lang = _ID_LANG_)
+        LEFT JOIN (_DB_PREFIX_image im INNER JOIN _DB_PREFIX_image_shop ims ON im.id_image = ims.id_image)
+          ON (p.id_product = im.id_product AND ims.id_shop = _ID_SHOP_ AND _IMS_COVER_)
+        LEFT OUTER JOIN _DB_PREFIX_product_attribute pa
+          ON (p.id_product = pa.id_product)
+        LEFT JOIN _DB_PREFIX_product_supplier psp
+          ON (p.id_product = psp.id_product AND pa.id_product_attribute = psp.id_product_attribute)
+        INNER JOIN _DB_PREFIX_product_attribute_shop pas
+          ON (pas.id_product_attribute = pa.id_product_attribute AND pas.id_shop = _ID_SHOP_)
+        LEFT JOIN _DB_PREFIX_product_attribute_image pa_im
+          ON (pa_im.id_product_attribute = pa.id_product_attribute)
+        LEFT JOIN (_DB_PREFIX_tag tag
+            INNER JOIN _DB_PREFIX_product_tag pt ON tag.id_tag = pt.id_tag AND pt.id_lang = _ID_LANG_)
+          ON (pt.id_product = p.id_product)
+        LEFT JOIN _DB_PREFIX_stock_available sa
+          ON (p.id_product = sa.id_product
+            AND sa.id_product_attribute = IF(isnull(pa.id_product), 0, pa.id_product_attribute)
+            AND (sa.id_shop = _ID_SHOP_ OR
+            (sa.id_shop = 0 AND sa.id_shop_group = _ID_SHOPGROUP_)))
+      WHERE
+        __IS_ACTIVE__
+        __VISIBILITY__
+        __PRODUCT_IDS__
+        AND pa.id_product_attribute is not null
+        GROUP BY pa.id_product_attribute, p.id_product";
     }
 
     /**

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -32,6 +32,14 @@ class DfTools
     protected static $rootCategoryIds;
     protected static $cachedCategoryPaths = [];
 
+    /** @var array List of server settings */
+    public static $_servers = [];
+
+    /** @var null Flag used to load slave servers only once.
+     * See loadSlaveServers() method
+     */
+    public static $_slave_servers_loaded = null;
+
     /**
      * Hash password.
      *
@@ -492,6 +500,74 @@ class DfTools
     }
 
 
+    /**
+     * Creates a new database instance.
+     *
+     * This method initializes and returns a new database connection instance, either to the master server
+     * or to a slave server based on the parameter. It manages connection pooling and sets up
+     * unbuffered queries for PDO connections to handle large datasets efficiently.
+     *
+     * @param bool $master Whether to connect to the master server (true) or a slave server (false)
+     * @return \Db Database instance with active connection
+     */
+    protected static function getNewDbInstance($master = true)
+    {
+        static $id = 0;
+
+        // This MUST not be declared with the class members because some defines (like _DB_SERVER_) may not exist yet (the constructor can be called directly with params)
+        if (!self::$_servers) {
+            self::$_servers = [
+                ['server' => _DB_SERVER_, 'user' => _DB_USER_, 'password' => _DB_PASSWD_, 'database' => _DB_NAME_], /* MySQL Master server */
+            ];
+        }
+
+        if (!$master) {
+            self::loadSlaveServers();
+        }
+
+        $total_servers = count(self::$_servers);
+        if ($master || $total_servers == 1) {
+            $id_server = 0;
+        } else {
+            ++$id;
+            $id_server = ($total_servers > 2 && ($id % $total_servers) != 0) ? $id % $total_servers : 1;
+        }
+
+        $class = \Db::getClass();
+        $instance = new $class(
+            self::$_servers[$id_server]['server'],
+            self::$_servers[$id_server]['user'],
+            self::$_servers[$id_server]['password'],
+            self::$_servers[$id_server]['database'],
+            false
+        );
+        $link = $instance->connect();
+        if ( 'DbPDO' === $class && method_exists($link, 'setAttribute')) {
+            // Set the PDO attribute to not use buffered queries
+            // This is needed to avoid memory issues with large datasets
+
+            $link->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        }
+        return $instance;
+    }
+
+     /**
+     * Loads configuration settings for slave servers if needed.
+     */
+    protected static function loadSlaveServers()
+    {
+        if (self::$_slave_servers_loaded !== null) {
+            return;
+        }
+
+        // Add here your slave(s) server(s) in this file
+        if (file_exists(_PS_ROOT_DIR_ . '/config/db_slave_server.inc.php')) {
+            self::$_servers = array_merge(self::$_servers, require (_PS_ROOT_DIR_ . '/config/db_slave_server.inc.php'));
+        }
+
+        self::$_slave_servers_loaded = true;
+    }
+
     public static function getAvailableProductsForLanguageV2($idLang, $checkLeadership=true, $limit = false, $offset = false, $ids = null)
     {
 
@@ -504,7 +580,7 @@ class DfTools
         }
 
         // Product table fields
-        $query->select('p.ean13 AS ean13, p.upc, p.reference');
+        $query->select('p.ean13 AS ean13, p.upc, p.reference, p.supplier_reference');
 
         // Product shop table fields
         $query->select('product_shop.id_product, product_shop.show_price, product_shop.available_for_order');
@@ -644,7 +720,7 @@ class DfTools
         // echo "<pre>";
         // var_dump($query->__toString());
         // echo "</pre>";
-        return \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
+        return self::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 
     public static function getProductVariationsV2($idProduct, $idLang) {
@@ -704,7 +780,7 @@ class DfTools
 
         $query->groupBy('product_attribute_shop.id_product, product_attribute_shop.id_product_attribute');
 
-        return \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
+        return self::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -600,7 +600,7 @@ class DfTools
         }
 
         // Product table fields
-        $query->select('p.ean13 AS ean13, p.upc, p.reference, p.supplier_reference');
+        $query->select('p.ean13 AS ean13, p.upc, p.reference');
 
         // Product shop table fields
         $query->select('product_shop.id_product, product_shop.show_price, product_shop.available_for_order');
@@ -628,7 +628,7 @@ class DfTools
         );
 
         // Product supplier reference
-        $query->select('psp.product_supplier_reference AS supplier_reference');
+        $query->select('COALESCE(psp.product_supplier_reference, p.supplier_reference) as supplier_reference, psp.product_supplier_reference AS variation_supplier_reference');
         $query->leftJoin(
             'product_supplier',
             'psp',
@@ -716,7 +716,7 @@ class DfTools
             ) vc ON vc.id_product = product_shop.id_product');
 
 
-        $query->select('null AS variation_reference, null AS variation_supplier_reference, null AS variation_mpn,
+        $query->select('null AS variation_reference, null AS variation_mpn,
             null AS variation_ean13, null AS variation_upc, null AS variation_image_id');
 
         if (self::versionGte('1.5.1.0')) {
@@ -797,8 +797,7 @@ class DfTools
         $query->leftJoin(
             'product_supplier',
             'psp',
-            'p.id_supplier = psp.id_supplier
-            AND p.`id_product` = psp.`id_product`
+            'p.`id_product` = psp.`id_product`
             AND psp.`id_product_attribute` = product_attribute_shop.id_product_attribute'
         );
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -679,7 +679,7 @@ class DfTools
         $query->leftJoin(
             'tag',
             'tag',
-            'pt.`id_tag` = tag.`id_tag` AND tag.id_lang = ' . (int) $idLang
+            'pt.`id_tag` = tag.`id_tag`'
         );
 
         $query->select('GROUP_CONCAT(cl.id_category ORDER BY cl.id_category) AS category_ids');

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1453,16 +1453,28 @@ class DfTools
             return null;
         }
 
+        // Replace control characters with spaces
         $text = preg_replace('/[^\P{C}]+/u', ' ', $text);
-        $text = str_replace(["\t", "\r", "\n"], ' ', $text);
-        $text = strip_tags($text);
-        $text = preg_replace('/\s+/', ' ', $text);
-        $text = trim($text);
-        $text = preg_replace('/^["\']+/', '', $text); // remove first quotes
-        $text = str_replace(self::TXT_SEPARATOR, '&#124;', $text);
-        $text = stripcslashes($text);
-        $text = str_replace('\"', '"', $text);
 
+        // Remove HTML and PHP tags
+        $text = strip_tags($text);
+
+        // Normalize whitespace by replacing consecutive spaces with a single space
+        $text = preg_replace('/\s+/', ' ', $text);
+
+        // Remove leading and trailing whitespace
+        $text = trim($text);
+
+        // Replace text separator with HTML entity for pipe character
+        $text = str_replace(self::TXT_SEPARATOR, '&#124;', $text);
+
+        // // Would remove backslashes from escaped chars
+        // $text = stripcslashes($text);
+
+        // Remove escaping as for CSV we escape with "
+        $text = str_replace('\\', '', $text);
+
+        // Filter out invalid UTF-8 sequences using a predefined regex pattern
         return preg_replace(self::VALID_UTF8, '$1', $text);
     }
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -935,7 +935,7 @@ class DfTools
                 p.upc,
                 p.reference,
                 p.supplier_reference,
-                IF(ISNULL(pan.attribute_n), true, false) AS df_group_leader,
+                IF(ISNULL(pan.attribute_n) OR pan.attribute_n > 0, true, false) AS df_group_leader,
                 pl.name,
                 pl.description,
                 pl.description_short,

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -934,7 +934,7 @@ class DfTools
                 p.upc,
                 p.reference,
                 p.supplier_reference,
-                IF(ISNULL(pan.attribute_n) OR pan.attribute_n > 0, true, false) AS df_group_leader,
+                IF(NOT ISNULL(pan.attribute_n) AND pan.attribute_n > 0, true, false) AS df_group_leader,
                 pl.name,
                 pl.description,
                 pl.description_short,


### PR DESCRIPTION
In this PR we refactor the query for maintanability and performance. We also use DBQuery that improves query building. 

We fetch the results using `foreach` rather than `fetch`. Keep in mind that recent versions of PHP replaces `libmysql` with `mysqlnd` that impacts memory usage as follows:

> When using libmysqlclient as library PHP's memory limit won't count the memory used for result sets unless the data is fetched into PHP variables. With mysqlnd the memory accounted for will include the full result set.

So maybe we have to look on how to overcome this situation opening more database connections and use `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, FALSE`

See: https://phpdelusions.net/pdo#mysqlnd

This is a sample from two executions the first one with the query and the second using two connections and unbuffered queries. Before each execution I ran `RESET QUERY CACHE` and `FLUSH QUERY CACHE`. We can observe that the second execution use more connections but the traffic and number of queries are reduced significatively.

![image](https://github.com/user-attachments/assets/dda2e003-0e77-400f-81d4-daf50908e57c)

## Benchmarks

I have obtained the following metrics comparing the new algorithm versus the huge SQL query. 

- **Memory usage has been reduced by 60%** on a sustained basis
- The elapsed time to complete a request vary depending on the nature of the catalog. But for complete download, without pagination **I have got a speedup between 0.8 and 1.8**. So it sits between no improvement or slower and the half of time. **But where it really shines is when paginating, where the speedup grows up between 5 and 10**. All of them with the memory associated memory reduction.

