### PR TITLE
PLUGINRANGERS-323 | Wrapped `Context::getContext()` into a single function to decrease the validator warnings

### DIFF
--- a/controllers/admin/DoofinderAdminController.php
+++ b/controllers/admin/DoofinderAdminController.php
@@ -12,6 +12,9 @@
  * @copyright Doofinder
  * @license   GPLv3
  */
+
+use PrestaShop\Module\Doofinder\Src\Entity\DfTools;
+
 if (!defined('_PS_VERSION_')) {
     exit;
 }
@@ -20,7 +23,7 @@ class DoofinderAdminController extends ModuleAdminController
 {
     public function __construct()
     {
-        $this->context = Context::getContext();
+        $this->context = DfTools::getContext();
         $this->module = Module::getInstanceByName('doofinder');
         $this->bootstrap = true;
         $this->lang = false;

--- a/controllers/front/config.php
+++ b/controllers/front/config.php
@@ -38,7 +38,7 @@ class DoofinderConfigModuleFrontController extends ModuleFrontController
         $module = Module::getInstanceByName('doofinder');
         $autoinstallerToken = Tools::getValue('token');
         if ($autoinstallerToken) {
-            $redirect = Context::getContext()->shop->getBaseURL(true, false)
+            $redirect = DfTools::getContext()->shop->getBaseURL(true, false)
                 . $module->getPathUri() . 'config.php';
             $tmpToken = DfTools::encrypt($redirect);
             if ($tmpToken == $autoinstallerToken) {

--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.1.14';
+        $this->version = '5.1.15';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feeds/category.php
+++ b/feeds/category.php
@@ -44,7 +44,7 @@ header('Content-Type:text/plain; charset=utf-8');
 DfTools::validateSecurityToken(Tools::getValue('dfsec_hash'));
 
 // CONTEXT
-$context = Context::getContext();
+$context = DfTools::getContext();
 $shop = new Shop((int) $context->shop->id);
 if (!$shop->id) {
     exit('NOT PROPERLY CONFIGURED');

--- a/feeds/cms.php
+++ b/feeds/cms.php
@@ -44,7 +44,7 @@ header('Content-Type:text/plain; charset=utf-8');
 DfTools::validateSecurityToken(Tools::getValue('dfsec_hash'));
 
 // CONTEXT
-$context = Context::getContext();
+$context = DfTools::getContext();
 $shop = new Shop((int) $context->shop->id);
 if (!$shop->id) {
     exit('NOT PROPERLY CONFIGURED');

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -73,7 +73,7 @@ function arrayMergeByIdProduct($array1 = [], $array2 = [])
     return $result;
 }
 
-$context = Context::getContext();
+$context = DfTools::getContext();
 
 $shop = new Shop((int) $context->shop->id);
 if (!$shop->id) {

--- a/src/Entity/DfCategoryBuild.php
+++ b/src/Entity/DfCategoryBuild.php
@@ -59,7 +59,7 @@ class DfCategoryBuild
 
     private function assign()
     {
-        $this->link = \Context::getContext()->link;
+        $this->link = DfTools::getContext()->link;
     }
 
     private function buildCategory($idCategory)

--- a/src/Entity/DfCmsBuild.php
+++ b/src/Entity/DfCmsBuild.php
@@ -57,7 +57,7 @@ class DfCmsBuild
 
     private function assign()
     {
-        $this->link = \Context::getContext()->link;
+        $this->link = DfTools::getContext()->link;
     }
 
     private function buildCms($idCms)

--- a/src/Entity/DfProductBuild.php
+++ b/src/Entity/DfProductBuild.php
@@ -48,7 +48,7 @@ class DfProductBuild
         $this->attributesShown = DfTools::cfg($idShop, 'DF_GROUP_ATTRIBUTES_SHOWN', '');
         $this->displayPrices = (bool) DfTools::cfg($idShop, 'DF_GS_DISPLAY_PRICES', DoofinderConstants::YES);
         $this->imageSize = \Configuration::get('DF_GS_IMAGE_SIZE');
-        $this->link = \Context::getContext()->link;
+        $this->link = DfTools::getContext()->link;
         $this->linkRewriteConf = \Configuration::get('PS_REWRITING_SETTINGS');
         $this->productVariations = (bool) \Configuration::get('DF_SHOW_PRODUCT_VARIATIONS');
         $this->showProductFeatures = (bool) \Configuration::get('DF_SHOW_PRODUCT_FEATURES');

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -121,7 +121,7 @@ class DfTools
     public static function getHashidKeys()
     {
         $hashidKeys = [];
-        $context = \Context::getContext();
+        $context = self::getContext();
         $currencies = \Currency::getCurrenciesByIdShop($context->shop->id);
         $languages = \Language::getLanguages(true, $context->shop->id);
         foreach ($languages as $language) {
@@ -852,6 +852,7 @@ class DfTools
 
         return $path;
     }
+
     /**
      * Returns an array containing the paths for categories for a product in a language for the selected shop.
      *
@@ -864,7 +865,7 @@ class DfTools
     public static function getCategoryLinksById($categoryIds, $idLang, $idShop)
     {
         $categoryIds = explode(',', $categoryIds);
-        $link = \Context::getContext()->link;
+        $link = self::getContext()->link;
         $urls = [];
 
         foreach ($categoryIds as $category_id) {
@@ -1203,7 +1204,7 @@ class DfTools
      */
     public static function getLanguageFromRequest()
     {
-        $context = \Context::getContext();
+        $context = self::getContext();
         $idLang = \Tools::getValue('language', $context->language->id);
 
         if (!is_numeric($idLang)) {
@@ -1231,7 +1232,7 @@ class DfTools
             return new \Currency(\Currency::getIdByIsoCode($idCurrency));
         }
 
-        return new \Currency(\Context::getContext()->currency->id);
+        return new \Currency(self::getContext()->currency->id);
     }
 
     /**
@@ -1258,7 +1259,7 @@ class DfTools
         }
 
         if (!$idCurrency) {
-            $context = \Context::getContext();
+            $context = self::getContext();
             $idCurrency = $context->currency->id;
         }
 
@@ -1275,7 +1276,7 @@ class DfTools
      */
     public static function getModuleLink($path, $ssl = false)
     {
-        $context = \Context::getContext();
+        $context = self::getContext();
         $base = (($ssl && \Configuration::get('PS_SSL_ENABLED')) ? 'https://' : 'http://') . $context->shop->domain;
 
         return $base . _MODULE_DIR_ . basename(dirname(__FILE__)) . '/' . $path;
@@ -1292,7 +1293,7 @@ class DfTools
 
     public static function getImageLink($idProduct, $idImage, $linkRewrite, $imageSize)
     {
-        $context = \Context::getContext();
+        $context = self::getContext();
         if (empty($idProduct) || empty($idImage)) {
             return '';
         }
@@ -1448,7 +1449,7 @@ class DfTools
 
     public static function getMinVariantPrices($products, $includeTaxes, $currencies, $idLang, $idShop)
     {
-        $context = \Context::getContext();
+        $context = self::getContext();
         $minPricesByProductId = [];
         $products = self::maybeAddVariantsFirstParent($products, $idLang, $idShop);
         foreach ($products as $product) {
@@ -1676,6 +1677,11 @@ class DfTools
         return \Cache::retrieve($cacheKey);
     }
 
+    public static function getContext()
+    {
+        return \Context::getContext();
+    }
+
     public static function str_contains($haystack, $needle)
     {
         if (function_exists('str_contains')) {
@@ -1687,7 +1693,7 @@ class DfTools
 
     private static function getVariantUrl($product, $context)
     {
-        $context = \Context::getContext();
+        $context = self::getContext();
         $cfgModRewrite = self::cfg($context->shop->id, 'PS_REWRITING_SETTINGS', DoofinderConstants::YES);
 
         return self::cleanURL(

--- a/src/Entity/DoofinderAdminPanelView.php
+++ b/src/Entity/DoofinderAdminPanelView.php
@@ -58,7 +58,7 @@ class DoofinderAdminPanelView
     public function getContent()
     {
         $stop = $this->getWarningMultishopHtml();
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         if ($stop) {
             return $stop;
         }
@@ -118,7 +118,7 @@ class DoofinderAdminPanelView
         $context->smarty->assign('paramsPopup', $paramsPopup);
         $context->smarty->assign('doofinderAdminUrl', sprintf(DoofinderConstants::DOOMANAGER_REGION_URL, ''));
 
-        $link = \Context::getContext()->link;
+        $link = DfTools::getContext()->link;
         $context->smarty->assign('ajaxUrl', $link->getPageLink('module-doofinder-ajax'));
         $context->smarty->assign('configUrl', $link->getPageLink('module-doofinder-config'));
 
@@ -155,7 +155,7 @@ class DoofinderAdminPanelView
         }
 
         if (\Shop::getContext() == \Shop::CONTEXT_GROUP || \Shop::getContext() == \Shop::CONTEXT_ALL) {
-            $context = \Context::getContext();
+            $context = DfTools::getContext();
             $context->smarty->assign('text_one_shop', $this->module->l('You cannot manage Doofinder from a \'All Shops\' or a \'Group Shop\' context, select directly the shop you want to edit', 'doofinderadminpanelview'));
             $stop = $context->smarty->fetch(self::getLocalPath() . 'views/templates/admin/message_manage_one_shop.tpl');
         }
@@ -165,7 +165,7 @@ class DoofinderAdminPanelView
 
     public function getWarningModuleNotEnabledHtml()
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $context->smarty->assign('text_one_shop', $this->module->l('You cannot manage Doofinder from a shop context where the module is deactivated. Please activate it to access its features.', 'doofinderadminpanelview'));
         return $context->smarty->fetch(self::getLocalPath() . 'views/templates/admin/message_manage_one_shop.tpl');
     }
@@ -187,7 +187,7 @@ class DoofinderAdminPanelView
 
     public static function displayGeneralMsg($string, $type, $alert, $link = false, $raw = false)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $context->smarty->assign(
             [
                 'd_type_message' => $type,
@@ -230,7 +230,7 @@ class DoofinderAdminPanelView
      */
     protected function isConfigured()
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShop = $context->shop->id;
         $multishopEnable = (bool) \Configuration::get('PS_MULTISHOP_FEATURE_ACTIVE');
         $defaultShopId = (int) \Configuration::get('PS_SHOP_DEFAULT');
@@ -268,7 +268,7 @@ class DoofinderAdminPanelView
     protected function renderFormDataFeed($adv = false, $skip = false)
     {
         $helper = new \HelperForm();
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShop = $context->shop->id;
         $helper->show_toolbar = false;
         $helper->table = $this->module->getTable();
@@ -292,7 +292,7 @@ class DoofinderAdminPanelView
             'id_language' => $context->language->id,
         ];
 
-        if (!$this->showNewShopForm(\Context::getContext()->shop)) {
+        if (!$this->showNewShopForm(DfTools::getContext()->shop)) {
             $validUpdateOnSave = UpdateOnSave::isValid();
             $html .= $helper->generateForm([$this->getConfigFormDataFeed($validUpdateOnSave)]);
             // Store information
@@ -314,7 +314,7 @@ class DoofinderAdminPanelView
     protected function renderFormAdvanced()
     {
         $helper = new \HelperForm();
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $helper->show_toolbar = false;
         $helper->table = $this->module->getTable();
         $helper->module = $this;
@@ -347,7 +347,7 @@ class DoofinderAdminPanelView
      */
     protected function getConfigFormDataFeed($validUpdateOnSave = false)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         if ($validUpdateOnSave) {
             $disabled = false;
             $query = [
@@ -369,7 +369,7 @@ class DoofinderAdminPanelView
         }
 
         $selectCommonFieldsForAttributesShownOptions = [
-            'query' => \AttributeGroup::getAttributesGroups(\Context::getContext()->language->id),
+            'query' => \AttributeGroup::getAttributesGroups(DfTools::getContext()->language->id),
             'id' => 'id_attribute_group',
             'name' => 'name',
         ];
@@ -485,7 +485,7 @@ class DoofinderAdminPanelView
 
     private function checkboxSelectorFormatHtml($configs)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $valueSelector = $configs['id'];
         $nameSelector = $configs['name'];
         $fieldName = $configs['field'];
@@ -696,7 +696,7 @@ class DoofinderAdminPanelView
     private function getFeedURLs()
     {
         $urls = [];
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $languages = \Language::getLanguages(true, $context->shop->id);
         $multipriceEnabled = \Configuration::get('DF_MULTIPRICE_ENABLED');
 

--- a/src/Entity/DoofinderApi.php
+++ b/src/Entity/DoofinderApi.php
@@ -607,8 +607,8 @@ class DoofinderApi
     {
         $result = false;
         $messages = '';
-        $currency = \Tools::strtoupper(\Context::getContext()->currency->iso_code);
-        $context = \Context::getContext();
+        $currency = \Tools::strtoupper(DfTools::getContext()->currency->iso_code);
+        $context = DfTools::getContext();
         $apiKeyMsgAlreadyShown = false;
         $messagesArray = [
             'errorQueryLimit' => [

--- a/src/Entity/DoofinderApiLanding.php
+++ b/src/Entity/DoofinderApiLanding.php
@@ -86,7 +86,7 @@ class DoofinderApiLanding
         }
         $queryName = \Tools::getValue('df_query_name', false);
         DoofinderConfig::debug('Search On API Start');
-        $hashid = SearchEngine::getHashId(\Context::getContext()->language->id, \Context::getContext()->currency->id);
+        $hashid = SearchEngine::getHashId(DfTools::getContext()->language->id, DfTools::getContext()->currency->id);
         $apiKey = \Configuration::get('DF_API_KEY');
         $showVariations = \Configuration::get('DF_SHOW_PRODUCT_VARIATIONS');
         if ((int) $showVariations !== 1) {
@@ -152,7 +152,7 @@ class DoofinderApiLanding
 
             $productPoolAttributes = implode(',', $productPoolAttributes);
 
-            $context = \Context::getContext();
+            $context = DfTools::getContext();
             // Avoids SQL Error
             if ($productPoolAttributes == '') {
                 $productPoolAttributes = '0';
@@ -191,7 +191,7 @@ class DoofinderApiLanding
                     ' . \Shop::addSqlAssociation('product_attribute', 'pa', false, ($showVariations) ? '' :
                             ' product_attribute_shop.default_on = 1') . '
                     ' . \Product::sqlStock('p', 'product_attribute_shop', false, $context->shop) :
-                    \Product::sqlStock('p', 'product', false, \Context::getContext()->shop)) . '
+                    \Product::sqlStock('p', 'product', false, DfTools::getContext()->shop)) . '
                 LEFT JOIN `' . _DB_PREFIX_ . 'manufacturer` m ON m.`id_manufacturer` = p.`id_manufacturer`
                 LEFT JOIN `' . _DB_PREFIX_ . 'image` i ON (i.`id_product` = p.`id_product` '
                 . ((\Combination::isFeatureActive() && $showVariations) ? '' : 'AND i.cover=1') . ') '

--- a/src/Entity/DoofinderConfig.php
+++ b/src/Entity/DoofinderConfig.php
@@ -27,7 +27,7 @@ class DoofinderConfig
             return;
         }
 
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShop = $context->shop->id;
         $idShopGroup = $context->shop->id_shop_group;
 

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -28,7 +28,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.14';
+    const VERSION = '5.1.15';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/src/Entity/DoofinderScript.php
+++ b/src/Entity/DoofinderScript.php
@@ -38,7 +38,7 @@ class DoofinderScript
         } else {
             $displayMobile = true;
         }
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         // PrestaShop 1.5 isn't responsive anyway
         $isMobile = false;
         if (method_exists($context, 'isMobile')) {

--- a/src/Entity/FormManager.php
+++ b/src/Entity/FormManager.php
@@ -43,7 +43,7 @@ class FormManager
         $formValues = [];
         $formUpdated = '';
         $messages = '';
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShop = $context->shop->id;
 
         $isFirstTime = (bool) \Tools::getValue('first_time', 0);

--- a/src/Entity/HookManager.php
+++ b/src/Entity/HookManager.php
@@ -63,7 +63,7 @@ class HookManager
      */
     public static function getHookCommonSmartyAssigns($languageCode, $currencyCode, $productLinks, $extraParams = false)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShopGroup = $context->shop->id_shop_group;
         $idShop = $context->shop->id;
 

--- a/src/Entity/SearchEngine.php
+++ b/src/Entity/SearchEngine.php
@@ -33,7 +33,7 @@ class SearchEngine
      */
     public static function getHashId($idLang, $idCurrency, $shopGroupId = null, $shopId = null)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $currIso = strtoupper(LanguageManager::getIsoCodeById($idCurrency));
         $lang = new \Language($idLang);
         $hashidKey = 'DF_HASHID_' . $currIso . '_' . strtoupper($lang->language_code);
@@ -69,7 +69,7 @@ class SearchEngine
      */
     public static function setSearchEnginesByConfig($idShopGroup = null, $idShop = null)
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $idShopGroup = isset($idShopGroup) ? $idShopGroup : $context->shop->id_shop_group;
         $idShop = isset($idShop) ? $idShop : $context->shop->id;
         $installationID = \Configuration::get('DF_INSTALLATION_ID', null, $idShopGroup, $idShop);

--- a/src/Entity/UpdateOnSave.php
+++ b/src/Entity/UpdateOnSave.php
@@ -326,7 +326,7 @@ class UpdateOnSave
      */
     public static function indexApiInvokeReindexing()
     {
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $region = \Configuration::get('DF_REGION');
         $apiKey = \Configuration::get('DF_API_KEY');
         $api = new DoofinderApiIndex($apiKey, $region);
@@ -356,7 +356,7 @@ class UpdateOnSave
         $region = \Configuration::get('DF_REGION');
         $apiKey = \Configuration::get('DF_API_KEY');
         $api = new DoofinderInstallation($apiKey, $region);
-        $context = \Context::getContext();
+        $context = DfTools::getContext();
         $installationId = \Configuration::get('DF_INSTALLATION_ID', null, $context->shop->id_shop_group, $context->shop->id);
         $decodeResponse = $api->isValidUpdateOnSave($installationId);
 

--- a/src/Entity/UrlManager.php
+++ b/src/Entity/UrlManager.php
@@ -49,7 +49,7 @@ class UrlManager
     public static function getFeedUrl($shopId, $language, $currency = null)
     {
         $shop = new \Shop($shopId);
-        \Context::getContext()->shop = $shop;
+        DfTools::getContext()->shop = $shop;
 
         $params = [
             'language' => \Tools::strtoupper($language),
@@ -60,7 +60,7 @@ class UrlManager
             $params['currency'] = \Tools::strtoupper($currency);
         }
 
-        $link = \Context::getContext()->link->getModuleLink(DoofinderConstants::NAME, 'feed', $params);
+        $link = DfTools::getContext()->link->getModuleLink(DoofinderConstants::NAME, 'feed', $params);
 
         /*
          * Cleans redundant parameters in URLs for PrestaShop 1.5.3
@@ -84,9 +84,9 @@ class UrlManager
     public static function getProcessCallbackUrl($shopId)
     {
         $shop = new \Shop($shopId);
-        \Context::getContext()->shop = $shop;
+        DfTools::getContext()->shop = $shop;
 
-        return \Context::getContext()->link->getModuleLink(DoofinderConstants::NAME, 'callback', []);
+        return DfTools::getContext()->link->getModuleLink(DoofinderConstants::NAME, 'callback', []);
     }
 
     public static function getInstallUrl($region)

--- a/templates/src/Entity/DoofinderConstants.php
+++ b/templates/src/Entity/DoofinderConstants.php
@@ -28,7 +28,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = '${DOOPHOENIX_REGION_URL}';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.14';
+    const VERSION = '5.1.15';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/doofinder-prestashop/issues/323

Don't be afraid about the number of files, the changes are just replacing `\Context::getContext()` by `DfTools::getContext()` or something similar (just 59 lines).

This PR won't avoid the warning, but at least it will decrease them to only 1.