### PR TITLE
use default db instance as fallback

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.1.18';
+        $this->version = '5.1.19';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -667,6 +667,13 @@ class DfTools
             $query->limit((int) $limit, (int) $offset);
         }
 
+        $result = DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
+        if ($result === false) {
+            error_log("[Doofinder fallback] executeS devolvió false. Intentando con Db::getInstance()");
+            $result = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+        }
+        return $result;
+
         return DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -669,7 +669,6 @@ class DfTools
 
         $result = DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
         if ($result === false) {
-            error_log("[Doofinder fallback] executeS devolvió false. Intentando con Db::getInstance()");
             $result = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
         }
         return $result;

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -670,11 +670,9 @@ class DfTools
         $result = DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
         if ($result === false) {
             error_log("[Doofinder fallback] executeS devolvió false. Intentando con Db::getInstance()");
-            $result = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query);
+            $result = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
         }
         return $result;
-
-        return DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
     }
 
     /**

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.18';
+    const VERSION = '5.1.19';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/templates/src/Entity/DoofinderConstants.php
+++ b/templates/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = '${DOOPHOENIX_REGION_URL}';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.18';
+    const VERSION = '5.1.19';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/3796

Depurando donde podía estar el error vi que si cambiaba 

```
return DfDb::getNewDbInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
```

por el uso de la instancia de base de datos "por defecto" de prestahsop (que es lo que utilizábamos antes), funciona: 

```
\Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
``` 

Como el cambio lo hizo @mursisoy y no estoy muy segura de que podamos utilizar siempre el "por defecto" de momento lo voy a dejar como fallback para posibles casos como este que les siga funcionando la indexación y lo revisaremos mas en detalle.