### PR TITLE
Request just ids and use them in the full query

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.1.19';
+        $this->version = '5.1.20';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1659,7 +1659,7 @@ class DfTools
     }
 
     /**
-     * Get the available products by their IDs.
+     * Get the ids of the available products.
      * When the catalog is large, this is much faster than get the products by offset and limit.
      *
      * @param int $idLang The language ID

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -516,7 +516,7 @@ class DfTools
     {
         
         if (null === $ids) {
-            $ids = self::getAvailableProductsByIds($idLang, $checkLeadership, $limit, $offset);
+            $ids = self::getAvailableProductsIds($idLang, $limit, $offset);
         }
 
         $query = new \DbQuery();
@@ -1667,7 +1667,7 @@ class DfTools
      * @param int|false $limit The maximum number of products to return
      * @param int|false $offset The offset for pagination
      */
-    public static function getAvailableProductsByIds($idLang, $checkLeadership = true, $limit = false, $offset = false, $ids = null)
+    public static function getAvailableProductsIds($idLang, $limit, $offset)
     {
         $idQuery = new \DbQuery();
         $idQuery->select('product_shop.id_product');
@@ -1685,14 +1685,12 @@ class DfTools
             }
         }
         
-        $idQuery->where('product_shop.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')');
-        
-        if (null !== $ids) {
-            $idQuery->where('product_shop.id_product IN (' . implode(',', array_map('intval', $ids)) . ')');
-        }
-        
+        $idQuery->where('product_shop.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')');      
         $idQuery->orderBy('product_shop.id_product');
-        $idQuery->limit((int) $limit, (int) $offset);
+        
+        if ($limit) {
+            $idQuery->limit((int) $limit, (int) $offset);
+        }
 
         $response = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($idQuery, false, false);
 
@@ -1701,7 +1699,7 @@ class DfTools
         }
 
         $productsIds = [];
-        
+
         foreach($response as $product) {
             $productsIds[] = $product['id_product'];
         }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1659,7 +1659,7 @@ class DfTools
     }
 
     /**
-     * Get the available products by their IDs. 
+     * Get the available products by their IDs.
      * When the catalog is large, this is much faster than get the products by offset and limit.
      *
      * @param int $idLang The language ID
@@ -1701,6 +1701,7 @@ class DfTools
         }
 
         $productsIds = [];
+        
         foreach($response as $product) {
             $productsIds[] = $product['id_product'];
         }

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -1685,7 +1685,7 @@ class DfTools
             }
         }
         
-        $idQuery->where('product_shop.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')');      
+        $idQuery->where('product_shop.id_shop IN (' . implode(', ', \Shop::getContextListShopID()) . ')');
         $idQuery->orderBy('product_shop.id_product');
         
         if ($limit) {
@@ -1700,7 +1700,7 @@ class DfTools
 
         $productsIds = [];
 
-        foreach($response as $product) {
+        foreach ($response as $product) {
             $productsIds[] = $product['id_product'];
         }
 

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.19';
+    const VERSION = '5.1.20';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/templates/src/Entity/DoofinderConstants.php
+++ b/templates/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = '${DOOPHOENIX_REGION_URL}';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.19';
+    const VERSION = '5.1.20';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by: https://github.com/doofinder/support/issues/3793

El cliente tien un catálogo mas o menos grande (350k) y le pasaba que las primeras páginas del feed las cargaba mas o menos rápido pero a medida de que aumentaba el tiempo iba subiendo mucho, por ejemplo, pidiendo offset=5000 y limit=1000 el servidor tardaba unos 3 minutos en contestar.

Lo he  cambiado para sacar en una query sencilla los ids que toca paginar y usar esos ids en la query final, para que no tenga que hacer toda la query para después hacer el limit y el offset, que parece que lleva mucho tiempo. Con el mismo offset y limit ahora tarda unos 19 segundos.