### PR TITLE
Include supplier_name in indexed information

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -39,7 +39,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.1.20';
+        $this->version = '5.1.21';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/feeds/product.php
+++ b/feeds/product.php
@@ -147,7 +147,7 @@ if ($shouldShowProductVariations) {
 $header = array_merge($header, [
     'title', 'link', 'description', 'alternate_description', 'meta_title', 'meta_description', 'image_link', 'main_category',
     'categories', 'category_merchandising', 'availability', 'brand', 'mpn', 'ean13', 'upc', 'reference',
-    'supplier_reference', 'extra_title_1', 'extra_title_2', 'tags',
+    'supplier_reference', 'supplier_name', 'extra_title_1', 'extra_title_2', 'tags',
 ]);
 
 if (DfTools::versionGte('1.7.0.0')) {

--- a/src/Entity/DfProductBuild.php
+++ b/src/Entity/DfProductBuild.php
@@ -249,6 +249,7 @@ class DfProductBuild
         $p['upc'] = DfTools::cleanString($product['upc']);
         $p['reference'] = DfTools::cleanString($product['reference']);
         $p['supplier_reference'] = DfTools::cleanString($product['supplier_reference']);
+        $p['supplier_name'] = DfTools::cleanString($product['supplier_name']);
         $p['extra_title_1'] = $p['title'];
         $p['extra_title_2'] = DfTools::splitReferences($p['title']);
 

--- a/src/Entity/DfTools.php
+++ b/src/Entity/DfTools.php
@@ -599,6 +599,9 @@ class DfTools
         $query->select('m.name AS manufacturer');
         $query->leftJoin('manufacturer', 'm', 'm.`id_manufacturer` = p.`id_manufacturer`');
 
+        $query->select('s.name AS supplier_name');
+        $query->leftJoin('supplier', 's', 's.`id_supplier` = p.`id_supplier`');
+
         $query->select('GROUP_CONCAT(tag.name ORDER BY tag.name) AS tags');
         $query->leftJoin(
             'product_tag',
@@ -671,6 +674,7 @@ class DfTools
         if ($result === false) {
             $result = \Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($query, false, false);
         }
+
         return $result;
     }
 
@@ -723,12 +727,15 @@ class DfTools
 
         // Product supplier reference
         $query->select('psp.product_supplier_reference AS variation_supplier_reference');
+        $query->select('s.name AS supplier_name');
         $query->leftJoin(
             'product_supplier',
             'psp',
             'p.`id_product` = psp.`id_product`
             AND psp.`id_product_attribute` = pa.id_product_attribute'
         );
+
+        $query->leftJoin('supplier', 's', 's.`id_supplier` = p.`id_supplier`');
 
         $query->select('sa.out_of_stock as out_of_stock, sa.quantity as stock_quantity');
         $query->leftJoin(
@@ -1633,7 +1640,9 @@ class DfTools
 
     /**
      * Validates the Installation ID.
+     *
      * @param string $installationId
+     *
      * @return bool
      */
     public static function validateInstallationId($installationId)
@@ -1641,12 +1650,15 @@ class DfTools
         if (!empty($installationId) && preg_match('/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/', $installationId)) {
             return true;
         }
+
         return false;
     }
 
     /**
      * Validates the Api Key.
+     *
      * @param string $apiKey
+     *
      * @return bool
      */
     public static function validateApiKey($apiKey)
@@ -1654,6 +1666,7 @@ class DfTools
         if (!empty($apiKey) && preg_match('/^[a-zA-Z0-9]{3}-[a-fA-F0-9]{40}$/', $apiKey)) {
             return true;
         }
+
         return false;
     }
 

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.1.20';
+    const VERSION = '5.1.21';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by https://github.com/doofinder/support/issues/3830.

Se incluye en la información a indexar el `supplier_name`.