### PR TITLE
PLUGINRANGERS-4056 | Escaped forward slashes in PrestaShop features

### DIFF
--- a/.env
+++ b/.env
@@ -27,7 +27,7 @@ PS_ENV=prod
 XDEBUG_HOST=172.17.0.1
 XDEBUG_KEY=phpstorm-xdebug
 
-PLUGIN_VERSION=5.2.0
+PLUGIN_VERSION=5.2.1
 DOOMANAGER_REGION_URL=https://%sadmin.doofinder.com
 DOOPLUGINS_REGION_URL=https://%splugins.doofinder.com
 DOOPHOENIX_REGION_URL=https://%ssearch.doofinder.com

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,6 @@ $config->setRiskyAllowed(true)
 
 /** @var Symfony\Component\Finder\Finder $finder */
 $finder = $config->setUsingCache(true)->getFinder();
-$finder->in(__DIR__)->exclude('vendor');
+$finder->in(__DIR__)->exclude('vendor')->exclude('html');
 
 return $config;

--- a/doofinder.php
+++ b/doofinder.php
@@ -66,7 +66,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '5.2.0';
+        $this->version = '5.2.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Entity/DfProductBuild.php
+++ b/src/Entity/DfProductBuild.php
@@ -493,11 +493,11 @@ class DfProductBuild
                 if (is_array($value)) {
                     $keyValueToReturn = [];
                     foreach ($value as $singleValue) {
-                        $keyValueToReturn[] = $key . '=' . $singleValue;
+                        $keyValueToReturn[] = $key . '=' . str_replace('/', '\/', $singleValue);
                     }
                     $formattedAttributes[] = implode('/', $keyValueToReturn);
                 } else {
-                    $formattedAttributes[] = $key . '=' . $value;
+                    $formattedAttributes[] = $key . '=' . str_replace('/', '\/', $value);
                 }
             }
             $product['attributes'] = str_replace('\"', '"', implode('/', $formattedAttributes));

--- a/src/Entity/DoofinderConstants.php
+++ b/src/Entity/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '5.2.0';
+    const VERSION = '5.2.1';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/4056

Before:

<img width="1215" height="560" alt="image" src="https://github.com/user-attachments/assets/e1b569f9-2ad9-4e88-9068-49c1074f43cd" />


After:

<img width="1215" height="560" alt="image" src="https://github.com/user-attachments/assets/8dc13cc2-d295-42bb-a909-66f31eac9e1a" />
