### PR TITLE
Redirect user on 'addProductToCart' error

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -66,7 +66,7 @@ class Doofinder extends Module
     {
         $this->name = 'doofinder';
         $this->tab = 'search_filter';
-        $this->version = '6.0.0';
+        $this->version = '6.0.1';
         $this->author = 'Doofinder (http://www.doofinder.com)';
         $this->ps_versions_compliancy = ['min' => '1.5', 'max' => '9.0.0'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';

--- a/src/Core/DoofinderConstants.php
+++ b/src/Core/DoofinderConstants.php
@@ -26,7 +26,7 @@ class DoofinderConstants
     const DOOPHOENIX_REGION_URL = 'https://%ssearch.doofinder.com';
     const GS_SHORT_DESCRIPTION = 1;
     const GS_LONG_DESCRIPTION = 2;
-    const VERSION = '6.0.0';
+    const VERSION = '6.0.1';
     const NAME = 'doofinder';
     const YES = 1;
     const NO = 0;

--- a/views/js/add-to-cart/doofinder-add_to_cart_ps17.js
+++ b/views/js/add-to-cart/doofinder-add_to_cart_ps17.js
@@ -125,19 +125,29 @@ let dfAddToCart = (cartOptions) => {
                 return;
             }
 
-            /* Possible errors variantions coming from the add to cart */
+            // Possible errors variations coming from Add to Cart
             if (event && event.eventType && ('updateProductInCart' === event.eventType || 
             'updateShoppingCart' === event.eventType || 
             'updateCart' === event.eventType || 
             'updateProductInCart' === event.eventType || 
             'updateProductQuantityInCart' === event.eventType || 
             'addProductToCart' === event.eventType)) {
-                let message = "Unknown error";
+
+                console.group(`Error of type '${event.eventType}' adding item to the cart.`);
+
+                // If the event is addProductToCart, redirect to the item link. 
+                // This will prevent silent errors from both customizable products and products with minimal quantity.
+                if (event.eventType === 'addProductToCart') {
+                    console.error("Redirecting user to the item page.");
+                    window.location.href = item_link;
+                }
+
                 /* Empirically I've have reproduced this error after loading another page in a specific moment  */
                 if (0 === event.resp.readyState) {
-                    message = "The connection was interrupted while adding to the cart";
+                    console.error("The connection was interrupted while adding to the cart");
                 }
-                console.error(message);
+
+                console.groupEnd();
                 cartOptions.statusPromise.reject(new DoofinderAddToCartError(message));
             }
         });

--- a/views/templates/front/scriptV9.tpl
+++ b/views/templates/front/scriptV9.tpl
@@ -14,7 +14,10 @@
 {if isset($installation_ID) && $installation_ID}
   <!-- START OF DOOFINDER ADD TO CART SCRIPT -->
   <script>
+    let item_link; 
     document.addEventListener('doofinder.cart.add', function(event) {
+      
+      item_link = event.detail.link;
 
       const checkIfCartItemHasVariation = (cartObject) => {
         return (cartObject.item_id === cartObject.grouping_id) ? false : true;


### PR DESCRIPTION
Fixes https://github.com/doofinder/support/issues/4086

- Redirect user to item page on `addProductToCart` error event. This avoids unhandled errors on customizable products and products with a `minimal_quantity` greater that one. 
- Improve error logging a bit. 