### PR TITLE
Remove interactive and tty from docker commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,14 @@ init: doofinder-configure
 
 # Check code consitency for the Doofinder Feed module using PHP Code Sniffer
 consistency:
-	docker run -it --rm -ePHP_CS_FIXER_IGNORE_ENV=1 \
+	docker run --rm -ePHP_CS_FIXER_IGNORE_ENV=1 \
 		-v$(shell pwd):/app -v/app/html -v/app/vendor \
 		composer:lts sh -c \
 		"composer install && \
 		vendor/bin/php-cs-fixer fix --diff --using-cache=no"
 
 dump-autoload:
-	docker run -it --rm -u $(shell id -u):$(shell id -g) -v$(shell pwd):/app composer:lts sh -c "composer install --no-dev && composer dump-autoload -o --no-dev"
+	docker run --rm -u $(shell id -u):$(shell id -g) -v$(shell pwd):/app composer:lts sh -c "composer install --no-dev && composer dump-autoload -o --no-dev"
 
 # Open an interactive shell in the web container as the 'application' user
 dev-console:


### PR DESCRIPTION
This options was causing an error when using this project with automated tools.