### PR TITLE
PLUGINRANGERS-401 | Avoid N+1 queries

### DIFF
--- a/src/Feed/DfProductBuild.php
+++ b/src/Feed/DfProductBuild.php
@@ -320,8 +320,8 @@ class DfProductBuild
             
             if ($this->productVariations && $product['variant_count'] > 0) {
                 // Get variations from cache
-                $variations = isset($this->cachedVariations[$productId]) 
-                    ? $this->cachedVariations[$productId] 
+                $variations = isset($this->cachedVariations[$productId])
+                    ? $this->cachedVariations[$productId]
                     : [];
                 
                 foreach ($variations as $variation) {

--- a/src/Utils/DfTools.php
+++ b/src/Utils/DfTools.php
@@ -642,7 +642,7 @@ class DfTools
         
         // Filter by feature keys if provided
         if ($featureKeys !== null && !empty($featureKeys)) {
-            $featureKeysEscaped = array_map(function($key) {
+            $featureKeysEscaped = array_map(function ($key) {
                 return "'" . pSQL($key) . "'";
             }, $featureKeys);
             $query->where('(fl.name IN (' . implode(',', $featureKeysEscaped) . ') OR fl.name IS NULL)');


### PR DESCRIPTION
:warning: THIS IS A DRAFT FOR NOW :warning: 

Required by:

- https://github.com/doofinder/doofinder-prestashop/issues/401

Numerical Comparison
Example with 1000 products, each with 3 variations and 4 categories:

BEFORE (without product preload)
Total: ~26,000 queries

AFTER (with preload):
Total: ~5-7 queries
