### PR TITLE
feat: expose dfPlatform variable for PrestaShop

### DIFF
--- a/src/Manager/HookManager.php
+++ b/src/Manager/HookManager.php
@@ -74,6 +74,7 @@ class HookManager
                 'dfPageType' => self::getPageType(),
                 'dfProductId' => self::getProductId(),
                 'dfCategoryName' => self::getCategoryName(),
+                'dfPlatform' => 'prestashop',
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- Adds `dfPlatform => 'prestashop'` to the `Media::addJsDef()` array in `HookManager.php`
- Value matches doomanager's store `platform` field
- Allows apps-loader to map plugin values to Doofinder's standardized platform identifiers

## Related
- doofinder/dooplugins#2225

## Test plan
- [ ] Verify `window.dfPlatform === 'prestashop'` on a PrestaShop storefront

🤖 Generated with [Claude Code](https://claude.com/claude-code)