### PR TITLE
PLUGINRANGERS-1711 | Update GitHub Actions checkout from v4 to v6

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/dooplugins/issues/1711