### PR TITLE
PLUGINRANGERS-5296 | Increase max compliancy to 9.1.5

### DIFF
--- a/doofinder.php
+++ b/doofinder.php
@@ -68,7 +68,7 @@ class Doofinder extends Module
         $this->tab = 'search_filter';
         $this->version = '8.2.4';
         $this->author = 'Doofinder (http://www.doofinder.com)';
-        $this->ps_versions_compliancy = ['min' => '1.6.1.0', 'max' => '9.1.4'];
+        $this->ps_versions_compliancy = ['min' => '1.6.1.0', 'max' => '9.1.5'];
         $this->module_key = 'd1504fe6432199c7f56829be4bd16347';
         $this->bootstrap = true;
         parent::__construct();


### PR DESCRIPTION
Required by:

- https://github.com/doofinder/support/issues/5296

I have not increased plugin version because I already did in a past merge that I haven't uplodaded yet (luckily)

Tested manually with my PS 9.1.5